### PR TITLE
Add UnitOfWork and ApplicationDbContext for database operations

### DIFF
--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Context/ApplicationDbContext.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Context/ApplicationDbContext.cs
@@ -1,0 +1,122 @@
+using Microsoft.EntityFrameworkCore;
+using Shopilent.Domain.Audit;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Payments;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Shipping;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Shopilent.Application.Abstractions.Events;
+using Shopilent.Application.Abstractions.Outbox;
+using Shopilent.Domain.Common;
+using Shopilent.Domain.Common.Events;
+using Shopilent.Domain.Outbox;
+using Shopilent.Infrastructure.Persistence.PostgreSQL.Extensions;
+using Attribute = Shopilent.Domain.Catalog.Attribute;
+using System.Reflection;
+
+namespace Shopilent.Infrastructure.Persistence.PostgreSQL.Context;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    // Identity domain
+    public DbSet<User> Users { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
+
+    // Shipping domain
+    public DbSet<Address> Addresses { get; set; }
+
+    // Catalog domain
+    public DbSet<Category> Categories { get; set; }
+    public DbSet<Product> Products { get; set; }
+    public DbSet<Attribute> Attributes { get; set; }
+    public DbSet<ProductCategory> ProductCategories { get; set; }
+    public DbSet<ProductAttribute> ProductAttributes { get; set; }
+    public DbSet<ProductVariant> ProductVariants { get; set; }
+    public DbSet<VariantAttribute> VariantAttributes { get; set; }
+
+    // Sales domain
+    public DbSet<Cart> Carts { get; set; }
+    public DbSet<CartItem> CartItems { get; set; }
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<OrderItem> OrderItems { get; set; }
+
+    // Payments domain
+    public DbSet<PaymentMethod> PaymentMethods { get; set; }
+    public DbSet<Payment> Payments { get; set; }
+
+    // Audit domain
+    public DbSet<AuditLog> AuditLogs { get; set; }
+
+    // Outbox pattern
+    public DbSet<OutboxMessage> OutboxMessages { get; set; }
+
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Ignore<DomainEvent>();
+
+        // Apply all configurations from the current assembly
+        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var events = ChangeTracker.Entries<AggregateRoot>()
+            .Select(e => e.Entity)
+            .Where(e => e.DomainEvents.Any())
+            .SelectMany(e => e.DomainEvents)
+            .ToList();
+
+        // Update timestamps
+        UpdateTimestamps();
+
+        // Process domain events before saving (create outbox messages)
+        if (events.Any())
+        {
+            var domainEventService = this.GetService<IDomainEventService>();
+
+            if (domainEventService != null)
+            {
+                foreach (var domainEvent in events)
+                {
+                    // This will add outbox messages to the current context
+                    await domainEventService.ProcessEventAsync(domainEvent, cancellationToken);
+                }
+
+                // Clear domain events
+                foreach (var entity in ChangeTracker.Entries<AggregateRoot>()
+                             .Select(e => e.Entity)
+                             .Where(e => e.DomainEvents.Any()))
+                {
+                    entity.ClearDomainEvents();
+                }
+            }
+        }
+
+        // Save everything in a single transaction
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        return result;
+    }
+
+    public override int SaveChanges()
+    {
+        // Update timestamps before saving changes
+        UpdateTimestamps();
+
+        return SaveChangesAsync().GetAwaiter().GetResult();
+    }
+
+    private void UpdateTimestamps()
+    {
+    }
+}

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/UnitOfWork.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/UnitOfWork.cs
@@ -1,0 +1,201 @@
+using Microsoft.EntityFrameworkCore.Storage;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Domain.Audit.Repositories;
+using Shopilent.Domain.Audit.Repositories.Read;
+using Shopilent.Domain.Audit.Repositories.Write;
+using Shopilent.Domain.Catalog.Repositories;
+using Shopilent.Domain.Catalog.Repositories.Read;
+using Shopilent.Domain.Catalog.Repositories.Write;
+using Shopilent.Domain.Common.Repositories;
+using Shopilent.Domain.Identity.Repositories;
+using Shopilent.Domain.Identity.Repositories.Read;
+using Shopilent.Domain.Identity.Repositories.Write;
+using Shopilent.Domain.Outbox.Repositories.Write;
+using Shopilent.Domain.Payments.Repositories;
+using Shopilent.Domain.Payments.Repositories.Read;
+using Shopilent.Domain.Payments.Repositories.Write;
+using Shopilent.Domain.Sales.Repositories;
+using Shopilent.Domain.Sales.Repositories.Read;
+using Shopilent.Domain.Sales.Repositories.Write;
+using Shopilent.Domain.Shipping.Repositories;
+using Shopilent.Domain.Shipping.Repositories.Read;
+using Shopilent.Domain.Shipping.Repositories.Write;
+using Shopilent.Infrastructure.Persistence.PostgreSQL.Context;
+
+namespace Shopilent.Infrastructure.Persistence.PostgreSQL;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly ApplicationDbContext _dbContext;
+    private IDbContextTransaction _transaction;
+    private bool _disposed;
+
+    public ICategoryReadRepository CategoryReader { get; }
+    public ICategoryWriteRepository CategoryWriter { get; }
+
+    public IProductReadRepository ProductReader { get; }
+    public IProductWriteRepository ProductWriter { get; }
+
+    public IAttributeReadRepository AttributeReader { get; }
+    public IAttributeWriteRepository AttributeWriter { get; }
+
+    public IProductVariantReadRepository ProductVariantReader { get; }
+    public IProductVariantWriteRepository ProductVariantWriter { get; }
+
+    public IUserReadRepository UserReader { get; }
+    public IUserWriteRepository UserWriter { get; }
+
+    public IRefreshTokenReadRepository RefreshTokenReader { get; }
+    public IRefreshTokenWriteRepository RefreshTokenWriter { get; }
+
+    public ICartReadRepository CartReader { get; }
+    public ICartWriteRepository CartWriter { get; }
+
+    public IOrderReadRepository OrderReader { get; }
+    public IOrderWriteRepository OrderWriter { get; }
+
+    public IPaymentReadRepository PaymentReader { get; }
+    public IPaymentWriteRepository PaymentWriter { get; }
+
+    public IPaymentMethodReadRepository PaymentMethodReader { get; }
+    public IPaymentMethodWriteRepository PaymentMethodWriter { get; }
+
+    public IAddressReadRepository AddressReader { get; }
+    public IAddressWriteRepository AddressWriter { get; }
+
+    public IAuditLogReadRepository AuditLogReader { get; }
+    public IAuditLogWriteRepository AuditLogWriter { get; }
+    
+    public IOutboxMessageWriteRepository OutboxMessageWriteWriter { get; }
+
+    public UnitOfWork(
+        ApplicationDbContext dbContext,
+        ICategoryReadRepository categoryRepository,
+        ICategoryWriteRepository categoryWriter,
+        IProductReadRepository productRepository,
+        IProductWriteRepository productWriter,
+        IAttributeReadRepository attributeRepository,
+        IAttributeWriteRepository attributeWriter,
+        IProductVariantReadRepository productVariantRepository,
+        IProductVariantWriteRepository productVariantWriter,
+        IUserReadRepository userRepository,
+        IUserWriteRepository userWriter,
+        IRefreshTokenReadRepository refreshTokenRepository,
+        IRefreshTokenWriteRepository refreshTokenWriter,
+        ICartReadRepository cartRepository,
+        ICartWriteRepository cartWriter,
+        IOrderReadRepository orderRepository,
+        IOrderWriteRepository orderWriter,
+        IPaymentReadRepository paymentRepository,
+        IPaymentWriteRepository paymentWriter,
+        IPaymentMethodReadRepository paymentMethodRepository,
+        IPaymentMethodWriteRepository paymentMethodWriter,
+        IAddressReadRepository addressRepository,
+        IAddressWriteRepository addressWriter,
+        IAuditLogReadRepository auditLogRepository,
+        IAuditLogWriteRepository auditLogWriter,
+        IOutboxMessageWriteRepository outboxMessageWriteWriter)
+    {
+        _dbContext = dbContext;
+        CategoryReader = categoryRepository;
+        CategoryWriter = categoryWriter;
+        ProductReader = productRepository;
+        ProductWriter = productWriter;
+        AttributeReader = attributeRepository;
+        AttributeWriter = attributeWriter;
+        ProductVariantReader = productVariantRepository;
+        ProductVariantWriter = productVariantWriter;
+        UserReader = userRepository;
+        UserWriter = userWriter;
+        RefreshTokenReader = refreshTokenRepository;
+        RefreshTokenWriter = refreshTokenWriter;
+        CartReader = cartRepository;
+        CartWriter = cartWriter;
+        OrderReader = orderRepository;
+        OrderWriter = orderWriter;
+        PaymentReader = paymentRepository;
+        PaymentWriter = paymentWriter;
+        PaymentMethodReader = paymentMethodRepository;
+        PaymentMethodWriter = paymentMethodWriter;
+        AddressReader = addressRepository;
+        AddressWriter = addressWriter;
+        AuditLogReader = auditLogRepository;
+        AuditLogWriter = auditLogWriter;
+        OutboxMessageWriteWriter = outboxMessageWriteWriter;
+    }
+
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> SaveEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        // Handle domain events if needed before saving
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        _transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+    }
+
+    public async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await _transaction?.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            if (_transaction != null)
+            {
+                _transaction.Dispose();
+                _transaction = null;
+            }
+        }
+    }
+
+    public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _transaction?.RollbackAsync(cancellationToken);
+        }
+        finally
+        {
+            if (_transaction != null)
+            {
+                _transaction.Dispose();
+                _transaction = null;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                _transaction?.Dispose();
+                _dbContext.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
- Implement `UnitOfWork` for transactional operations and repository access.
- Introduce `ApplicationDbContext` to manage database context for entities across all domains (`Identity`, `Catalog`, `Sales`, `Payments`, `Shipping`, `Audit`, and `Outbox`).