### PR TITLE
Add S3 object storage service with provider-specific configurations

### DIFF
--- a/Shopilent.Infrastructure.S3ObjectStorage/Extensions/StorageServiceExtensions.cs
+++ b/Shopilent.Infrastructure.S3ObjectStorage/Extensions/StorageServiceExtensions.cs
@@ -1,0 +1,74 @@
+using Amazon.S3;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Shopilent.Application.Abstractions.S3Storage;
+using Shopilent.Application.Settings.S3Storage;
+using Shopilent.Infrastructure.S3ObjectStorage.Services;
+
+namespace Shopilent.Infrastructure.S3ObjectStorage.Extensions;
+
+public static class StorageServiceExtensions
+{
+    public static IServiceCollection AddStorageServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<S3Settings>(configuration.GetSection("S3"));
+
+        var s3Settings = configuration.GetSection("S3").Get<S3Settings>();
+        if (s3Settings == null)
+            throw new ArgumentException("S3 settings are not configured");
+
+        services.AddScoped<IAmazonS3>(sp =>
+        {
+            var config = new AmazonS3Config
+            {
+                ForcePathStyle = s3Settings.ForcePathStyle
+            };
+
+            // Configure based on provider
+            switch (s3Settings.Provider)
+            {
+                case S3ProviderSettings.DigitalOcean:
+                    config.ServiceURL = s3Settings.ServiceUrl; // e.g., "https://nyc3.digitaloceanspaces.com"
+                    config.ForcePathStyle = false; // Digital Ocean uses virtual-hosted-style URLs
+                    break;
+
+                case S3ProviderSettings.MinIO:
+                    config.ServiceURL = s3Settings.ServiceUrl;
+                    config.ForcePathStyle = true;
+                    config.Timeout = TimeSpan.FromMinutes(5);
+                    break;
+
+                case S3ProviderSettings.Backblaze:
+                    config.ServiceURL = s3Settings.ServiceUrl;
+                    config.ForcePathStyle = true;
+                    config.UseHttp = false;  // Force HTTPS
+                    // Add headers to disable checksums
+                    config.SignatureVersion = "2";
+                    if (s3Settings.ServiceUrl.Contains(s3Settings.DefaultBucket))
+                    {
+                        // Strip bucket name from ServiceURL if it's there
+                        var uri = new Uri(s3Settings.ServiceUrl);
+                        var host = uri.Host;
+                        config.ServiceURL = $"https://{host}";
+                    }
+                    break;
+
+                case S3ProviderSettings.AWS:
+                default:
+                    config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(s3Settings.Region);
+                    break;
+            }
+
+            return new AmazonS3Client(
+                s3Settings.AccessKey,
+                s3Settings.SecretKey,
+                config);
+        });
+
+        services.AddScoped<IS3StorageService, S3StorageService>();
+
+        return services;
+    }
+}

--- a/Shopilent.Infrastructure.S3ObjectStorage/Services/S3StorageService.cs
+++ b/Shopilent.Infrastructure.S3ObjectStorage/Services/S3StorageService.cs
@@ -1,0 +1,222 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shopilent.Application.Abstractions.S3Storage;
+using Shopilent.Application.Settings.S3Storage;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+
+namespace Shopilent.Infrastructure.S3ObjectStorage.Services;
+
+public class S3StorageService : IS3StorageService
+{
+    private readonly IAmazonS3 _s3Client;
+    private readonly ILogger<S3StorageService> _logger;
+    private readonly S3Settings _settings;
+
+    public S3StorageService(
+        IAmazonS3 s3Client,
+        IOptions<S3Settings> settings,
+        ILogger<S3StorageService> logger)
+    {
+        _s3Client = s3Client;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task<Result<string>> UploadFileAsync(
+        string bucketName,
+        string key,
+        Stream fileStream,
+        string contentType,
+        IDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var transferUtility = new TransferUtility(_s3Client);
+            var request = new TransferUtilityUploadRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                InputStream = fileStream,
+                ContentType = contentType
+            };
+
+            if (metadata != null)
+            {
+                foreach (var (metaKey, value) in metadata)
+                {
+                    request.Metadata.Add(metaKey, value);
+                }
+            }
+
+            await transferUtility.UploadAsync(request, cancellationToken);
+
+            string url;
+            switch (_settings.Provider?.ToUpperInvariant())
+            {
+                case "DIGITALOCEAN":
+                    url = $"https://{bucketName}.{new Uri(_settings.ServiceUrl).Host}/{key}";
+                    break;
+
+                case "BACKBLAZE":
+                    var serviceUri = new Uri(_settings.ServiceUrl);
+                    url = $"https://{serviceUri.Host}/{key}";
+                    break;
+
+                default:
+                    url = $"{_settings.ServiceUrl}/{key}";
+                    break;
+            }
+
+            return Result.Success(url);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error uploading file to S3. Bucket: {Bucket}, Key: {Key}", bucketName, key);
+            return Result.Failure<string>(Error.Failure(message: $"Failed to upload file: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<Stream>> DownloadFileAsync(
+        string bucketName,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new GetObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key
+            };
+
+            var response = await _s3Client.GetObjectAsync(request, cancellationToken);
+            return Result.Success(response.ResponseStream);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return Result.Failure<Stream>(Error.NotFound(message: "File not found"));
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error downloading file from S3. Bucket: {Bucket}, Key: {Key}", bucketName, key);
+            return Result.Failure<Stream>(Error.Failure(message: $"Failed to download file: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<bool>> DeleteFileAsync(
+        string bucketName,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new DeleteObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key
+            };
+
+            await _s3Client.DeleteObjectAsync(request, cancellationToken);
+            return Result.Success(true);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting file from S3. Bucket: {Bucket}, Key: {Key}", bucketName, key);
+            return Result.Failure<bool>(Error.Failure(message: $"Failed to delete file: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<bool>> FileExistsAsync(
+        string bucketName,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new GetObjectMetadataRequest
+            {
+                BucketName = bucketName,
+                Key = key
+            };
+
+            await _s3Client.GetObjectMetadataAsync(request, cancellationToken);
+            return Result.Success(true);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return Result.Success(false);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error checking file existence in S3. Bucket: {Bucket}, Key: {Key}", bucketName, key);
+            return Result.Failure<bool>(Error.Failure(message: $"Failed to check file existence: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<string>> GetPresignedUrlAsync(
+        string bucketName,
+        string key,
+        TimeSpan expiry,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Expires = DateTime.UtcNow.Add(expiry)
+            };
+
+            var url = _s3Client.GetPreSignedURL(request);
+            if (_settings.Provider == "MinIO")
+            {
+                url = url.Replace(_settings.ServiceUrl.Replace("http", "https"), "http://localhost:9858");
+            }
+
+            return Result.Success(url);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error generating presigned URL. Bucket: {Bucket}, Key: {Key}", bucketName, key);
+            return Result.Failure<string>(Error.Failure(message: $"Failed to generate presigned URL: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<IEnumerable<S3ObjectInfo>>> ListFilesAsync(
+        string bucketName,
+        string? prefix = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new ListObjectsV2Request
+            {
+                BucketName = bucketName,
+                Prefix = prefix
+            };
+
+            var response = await _s3Client.ListObjectsV2Async(request, cancellationToken);
+            var objects = response.S3Objects.Select(obj => new S3ObjectInfo
+            {
+                Key = obj.Key,
+                Size = obj.Size,
+                LastModified = obj.LastModified,
+                ETag = obj.ETag
+            });
+
+            return Result.Success(objects);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "Error listing files in S3. Bucket: {Bucket}, Prefix: {Prefix}", bucketName, prefix);
+            return Result.Failure<IEnumerable<S3ObjectInfo>>(
+                Error.Failure(message: $"Failed to list files: {ex.Message}"));
+        }
+    }
+}


### PR DESCRIPTION
- Introduced `S3StorageService` for file upload, download, deletion, and metadata operations.
- Added `StorageServiceExtensions` to register S3 services with custom configurations for DigitalOcean, MinIO, AWS, and Backblaze providers.
- Configured support for presigned URLs and provider-specific URL structures.