### PR TITLE
Add `Identity` API endpoints for authentication-related operations

### DIFF
--- a/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordEndpointV1.cs
@@ -1,0 +1,74 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.ForgotPassword.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.ForgotPassword.V1;
+
+public class ForgotPasswordEndpointV1 : Endpoint<ForgotPasswordRequestV1, ApiResponse<string>>
+{
+    private readonly IMediator _mediator;
+
+    public ForgotPasswordEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/forgot-password");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("ForgotPassword")
+            .Produces<ApiResponse<string>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<string>>(StatusCodes.Status400BadRequest)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(ForgotPasswordRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<string>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Map the request to command
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = req.Email
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                ErrorType.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            var errorResponse = ApiResponse<string>.Failure(
+                result.Error.Message,
+                statusCode);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // For security reasons, always return success even if email doesn't exist
+        var response = ApiResponse<string>.Success(
+            "If the email exists, a password reset link has been sent to it.",
+            "Password reset email sent");
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordRequestV1.cs
@@ -1,0 +1,6 @@
+namespace Shopilent.API.Endpoints.Identity.ForgotPassword.V1;
+
+public class ForgotPasswordRequestV1
+{
+    public string Email { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ForgotPassword/V1/ForgotPasswordRequestValidatorV1.cs
@@ -1,0 +1,15 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.ForgotPassword.V1;
+
+public class ForgotPasswordRequestValidatorV1 : Validator<ForgotPasswordRequestV1>
+{
+    public ForgotPasswordRequestValidatorV1()
+    {
+        RuleFor(x => x.Email)
+            .Cascade(FluentValidation.CascadeMode.Stop)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Login/V1/LoginEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Login/V1/LoginEndpointV1.cs
@@ -1,0 +1,93 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.Login.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.Login.V1;
+
+public class LoginEndpointV1 : Endpoint<LoginRequestV1, ApiResponse<LoginResponseV1>>
+{
+    private readonly IMediator _mediator;
+
+    public LoginEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/login");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("Login")
+            .Produces<ApiResponse<LoginResponseV1>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<LoginResponseV1>>(StatusCodes.Status401Unauthorized)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(LoginRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<LoginResponseV1>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Map the request to command
+        var command = new LoginCommandV1
+        {
+            Email = req.Email,
+            Password = req.Password,
+            IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "Unknown",
+            UserAgent = HttpContext.Request.Headers.UserAgent.ToString()
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type == ErrorType.Unauthorized
+                ? StatusCodes.Status401Unauthorized
+                : StatusCodes.Status400BadRequest;
+
+            var errorResponse = new ApiResponse<LoginResponseV1>
+            {
+                Succeeded = false,
+                Message = result.Error.Message,
+                StatusCode = statusCode,
+                Errors = new[] { result.Error.Message }
+            };
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Handle successful login
+        // var (user, accessToken, refreshToken) = result.Value;
+        var loginResponse = result.Value;
+        var response = new ApiResponse<LoginResponseV1>
+        {
+            Succeeded = true,
+            Message = "Login successful",
+            StatusCode = StatusCodes.Status200OK,
+            Data = new LoginResponseV1
+            {
+                Id = loginResponse.User.Id,
+                Email = loginResponse.User.Email.Value,
+                FirstName = loginResponse.User.FullName.FirstName,
+                LastName = loginResponse.User.FullName.LastName,
+                EmailVerified = loginResponse.User.EmailVerified,
+                AccessToken = loginResponse.AccessToken,
+                RefreshToken = loginResponse.RefreshToken
+            }
+        };
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Login/V1/LoginRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Login/V1/LoginRequestV1.cs
@@ -1,0 +1,7 @@
+namespace Shopilent.API.Endpoints.Identity.Login.V1;
+
+public class LoginRequestV1
+{
+    public string Email { get; init; }
+    public string Password { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/Login/V1/LoginRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Login/V1/LoginRequestValidatorV1.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.Login.V1;
+
+public class LoginRequestValidatorV1 : Validator<LoginRequestV1>
+{
+    public LoginRequestValidatorV1()
+    {
+        RuleFor(x => x.Email)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Login/V1/LoginResponseV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Login/V1/LoginResponseV1.cs
@@ -1,0 +1,12 @@
+namespace Shopilent.API.Endpoints.Identity.Login.V1;
+
+public class LoginResponseV1
+{
+    public Guid Id { get; init; }
+    public string Email { get; init; }
+    public string FirstName { get; init; }
+    public string LastName { get; init; }
+    public bool EmailVerified { get; init; }
+    public string AccessToken { get; init; }
+    public string RefreshToken { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutEndpointV1.cs
@@ -1,0 +1,79 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.Logout.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.Logout.V1;
+
+public class LogoutEndpointV1 : Endpoint<LogoutRequestV1, ApiResponse<string>>
+{
+    private readonly IMediator _mediator;
+
+    public LogoutEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/logout");
+        Description(b => b
+            .WithName("Logout")
+            .Produces<ApiResponse<String>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<String>>(StatusCodes.Status401Unauthorized)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(LogoutRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<string>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+        // Map the request to command
+        var command = new LogoutCommandV1()
+        {
+            RefreshToken = req.RefreshToken,
+            Reason = req.Reason
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type == ErrorType.Unauthorized
+                ? StatusCodes.Status401Unauthorized
+                : StatusCodes.Status400BadRequest;
+
+            var errorResponse = new ApiResponse<String>
+            {
+                Succeeded = false,
+                Message = result.Error.Message,
+                StatusCode = statusCode,
+                Errors = new[] { result.Error.Message }
+            };
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Handle successful logout
+        var loginResponse = result.IsSuccess;
+        var response = new ApiResponse<String>
+        {
+            Succeeded = true,
+            Message = "Logout successful",
+            StatusCode = StatusCodes.Status200OK,
+            Data = "Logout successful"
+        };
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutRequestV1.cs
@@ -1,0 +1,10 @@
+using Shopilent.API.Endpoints.Identity.Login.V1;
+using Shopilent.Application.Features.Identity.Commands.Login.V1;
+
+namespace Shopilent.API.Endpoints.Identity.Logout.V1;
+
+public class LogoutRequestV1
+{
+    public string RefreshToken { get; init; }
+    public string Reason { get; init; } = "User logged out";
+}

--- a/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Logout/V1/LogoutRequestValidatorV1.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.Logout.V1;
+
+public class LogoutRequestValidatorV1 : Validator<LogoutRequestV1>
+{
+    public LogoutRequestValidatorV1()
+    {
+        RuleFor(x => x.RefreshToken)
+            .NotEmpty().WithMessage("Refresh token is required.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenEndpointV1.cs
@@ -1,0 +1,87 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.RefreshToken.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.RefreshToken.V1;
+
+public class RefreshTokenEndpointV1 : Endpoint<RefreshTokenRequestV1, ApiResponse<RefreshTokenResponseV1>>
+{
+    private readonly IMediator _mediator;
+
+    public RefreshTokenEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/refresh-token");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("RefreshToken")
+            .Produces<ApiResponse<RefreshTokenResponseV1>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<RefreshTokenResponseV1>>(StatusCodes.Status401Unauthorized)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(RefreshTokenRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<RefreshTokenResponseV1>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+        // Map the request to command
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = req.RefreshToken,
+            IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "Unknown",
+            UserAgent = HttpContext.Request.Headers.UserAgent.ToString()
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type == ErrorType.Unauthorized
+                ? StatusCodes.Status401Unauthorized
+                : StatusCodes.Status400BadRequest;
+
+            var errorResponse = new ApiResponse<RefreshTokenResponseV1>
+            {
+                Succeeded = false,
+                Message = result.Error.Message,
+                StatusCode = statusCode,
+                Errors = new[] { result.Error.Message }
+            };
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Handle successful token refresh
+        var response = new ApiResponse<RefreshTokenResponseV1>
+        {
+            Succeeded = true,
+            Message = "Token refresh successful",
+            StatusCode = StatusCodes.Status200OK,
+            Data = new RefreshTokenResponseV1
+            {
+                Id = result.Value.User.Id,
+                Email = result.Value.User.Email.Value,
+                FullName = $"{result.Value.User.FullName.FirstName} {result.Value.User.FullName.LastName}",
+                AccessToken = result.Value.AccessToken,
+                RefreshToken = result.Value.RefreshToken
+            }
+        };
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenRequestV1.cs
@@ -1,0 +1,6 @@
+namespace Shopilent.API.Endpoints.Identity.RefreshToken.V1;
+
+public class RefreshTokenRequestV1
+{
+    public string RefreshToken { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenRequestValidatorV1.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.RefreshToken.V1;
+
+public class RefreshTokenRequestValidatorV1 : Validator<RefreshTokenRequestV1>
+{
+    public RefreshTokenRequestValidatorV1()
+    {
+        RuleFor(x => x.RefreshToken)
+            .NotEmpty().WithMessage("Refresh token is required.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenResponseV1.cs
+++ b/Shopilent.API/Endpoints/Identity/RefreshToken/V1/RefreshTokenResponseV1.cs
@@ -1,0 +1,10 @@
+namespace Shopilent.API.Endpoints.Identity.RefreshToken.V1;
+
+public class RefreshTokenResponseV1
+{
+    public Guid Id { get; init; }
+    public string Email { get; init; }
+    public string FullName { get; init; }
+    public string AccessToken { get; init; }
+    public string RefreshToken { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/Register/V1/RegisterEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Register/V1/RegisterEndpointV1.cs
@@ -1,0 +1,90 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.Register.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.Register.V1;
+
+public class RegisterEndpointV1 : Endpoint<RegisterRequestV1, ApiResponse<RegisterResponseV1>>
+{
+    private readonly IMediator _mediator;
+
+    public RegisterEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/register");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("Register")
+            .Produces<ApiResponse<RegisterResponseV1>>(StatusCodes.Status201Created)
+            .Produces<ApiResponse<RegisterResponseV1>>(StatusCodes.Status400BadRequest)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(RegisterRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<RegisterResponseV1>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+        // Map the request to command
+        var command = new RegisterCommandV1
+        {
+            Email = req.Email,
+            Password = req.Password,
+            FirstName = req.FirstName,
+            LastName = req.LastName,
+            Phone = req.Phone
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var errorResponse = new ApiResponse<RegisterResponseV1>
+            {
+                Succeeded = false,
+                Message = result.Error.Message,
+                StatusCode = result.Error.Type == ErrorType.Validation
+                    ? StatusCodes.Status400BadRequest
+                    : StatusCodes.Status500InternalServerError,
+                Errors = new[] { result.Error.Message }
+            };
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Handle successful registration
+        var response = new ApiResponse<RegisterResponseV1>
+        {
+            Succeeded = true,
+            Message = "Registration successful",
+            StatusCode = StatusCodes.Status201Created,
+            Data = new RegisterResponseV1
+            {
+                Id = result.Value.User.Id,
+                Email = result.Value.User.Email.Value,
+                FirstName = result.Value.User.FullName.FirstName,
+                LastName = result.Value.User.FullName.LastName,
+                EmailVerified = result.Value.User.EmailVerified,
+                Message = "Please check your email to verify your account",
+                AccessToken = result.Value.AccessToken,
+                RefreshToken = result.Value.RefreshToken
+            }
+        };
+
+        await SendCreatedAtAsync("GetUserById", new { id = result.Value.User.Id }, response, cancellation: ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Register/V1/RegisterRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Register/V1/RegisterRequestV1.cs
@@ -1,0 +1,10 @@
+namespace Shopilent.API.Endpoints.Identity.Register.V1;
+
+public class RegisterRequestV1
+{
+    public string Email { get; init; }
+    public string Password { get; init; }
+    public string FirstName { get; init; }
+    public string LastName { get; init; }
+    public string Phone { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/Register/V1/RegisterRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Register/V1/RegisterRequestValidatorV1.cs
@@ -1,0 +1,36 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.Register.V1;
+
+public class RegisterRequestValidatorV1 : Validator<RegisterRequestV1>
+{
+    public RegisterRequestValidatorV1()
+    {
+        RuleFor(x => x.Email)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.");
+
+        RuleFor(x => x.Password)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters long.")
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
+            .Matches("[0-9]").WithMessage("Password must contain at least one number.")
+            .Matches("[^a-zA-Z0-9]").WithMessage("Password must contain at least one special character.");
+
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage("First name is required.")
+            .MaximumLength(100).WithMessage("First name must not exceed 100 characters.");
+
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage("Last name is required.")
+            .MaximumLength(100).WithMessage("Last name must not exceed 100 characters.");
+
+        RuleFor(x => x.Phone)
+            .Matches(@"^\+?[0-9\s\-\(\)]{7,20}$").WithMessage("Phone number is not valid.")
+            .When(x => !string.IsNullOrEmpty(x.Phone));
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/Register/V1/RegisterResponseV1.cs
+++ b/Shopilent.API/Endpoints/Identity/Register/V1/RegisterResponseV1.cs
@@ -1,0 +1,13 @@
+namespace Shopilent.API.Endpoints.Identity.Register.V1;
+
+public class RegisterResponseV1
+{
+    public Guid Id { get; init; }
+    public string Email { get; init; }
+    public string FirstName { get; init; }
+    public string LastName { get; init; }
+    public bool EmailVerified { get; init; }
+    public string Message { get; init; }
+    public string AccessToken { get; init; }
+    public string RefreshToken { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationEndpointV1.cs
@@ -1,0 +1,73 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.ResendVerification.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.ResendVerification.V1;
+
+public class ResendVerificationEndpointV1 : Endpoint<ResendVerificationRequestV1, ApiResponse<string>>
+{
+    private readonly IMediator _mediator;
+
+    public ResendVerificationEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/resend-verification");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("ResendVerification")
+            .Produces<ApiResponse<string>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<string>>(StatusCodes.Status400BadRequest)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(ResendVerificationRequestV1 req, CancellationToken ct)
+    {
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<string>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+        // Map the request to command
+        var command = new ResendVerificationCommandV1
+        {
+            Email = req.Email
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                ErrorType.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            var errorResponse = ApiResponse<string>.Failure(
+                result.Error.Message,
+                statusCode);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Return successful response
+        var response = ApiResponse<string>.Success(
+            "Verification email sent successfully. Please check your inbox.",
+            "Verification email sent");
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationRequestV1.cs
@@ -1,0 +1,6 @@
+namespace Shopilent.API.Endpoints.Identity.ResendVerification.V1;
+
+public class ResendVerificationRequestV1
+{
+    public string Email { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResendVerification/V1/ResendVerificationRequestValidatorV1.cs
@@ -1,0 +1,15 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.ResendVerification.V1;
+
+public class ResendVerificationRequestValidatorV1 : Validator<ResendVerificationRequestV1>
+{
+    public ResendVerificationRequestValidatorV1()
+    {
+        RuleFor(x => x.Email)
+            .Cascade(FluentValidation.CascadeMode.Stop)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordEndpointV1.cs
@@ -1,0 +1,77 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.ResetPassword.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.ResetPassword.V1;
+
+public class ResetPasswordEndpointV1 : Endpoint<ResetPasswordRequestV1, ApiResponse<string>>
+{
+    private readonly IMediator _mediator;
+
+    public ResetPasswordEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/auth/reset-password");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("ResetPassword")
+            .Produces<ApiResponse<string>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<string>>(StatusCodes.Status400BadRequest)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(ResetPasswordRequestV1 req, CancellationToken ct)
+    {
+        // Validate request early
+        if (ValidationFailed)
+        {
+            var errorResponse = ApiResponse<string>.Failure(
+                ValidationFailures.Select(f => f.ErrorMessage).ToArray(),
+                StatusCodes.Status400BadRequest);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Map the request to command
+        var command = new ResetPasswordCommandV1
+        {
+            Token = req.Token,
+            NewPassword = req.NewPassword,
+            ConfirmPassword = req.ConfirmPassword
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                ErrorType.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            var errorResponse = ApiResponse<string>.Failure(
+                result.Error.Message,
+                statusCode);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Return successful response
+        var response = ApiResponse<string>.Success(
+            "Password has been reset successfully. You can now log in with your new password.",
+            "Password reset successful");
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordRequestV1.cs
@@ -1,0 +1,8 @@
+namespace Shopilent.API.Endpoints.Identity.ResetPassword.V1;
+
+public class ResetPasswordRequestV1
+{
+    public string Token { get; init; }
+    public string NewPassword { get; init; }
+    public string ConfirmPassword { get; init; }
+}

--- a/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Identity/ResetPassword/V1/ResetPasswordRequestValidatorV1.cs
@@ -1,0 +1,27 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Shopilent.API.Endpoints.Identity.ResetPassword.V1;
+
+public class ResetPasswordRequestValidatorV1 : Validator<ResetPasswordRequestV1>
+{
+    public ResetPasswordRequestValidatorV1()
+    {
+        RuleFor(x => x.Token)
+            .NotEmpty().WithMessage("Token is required.");
+
+        RuleFor(x => x.NewPassword)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters long.")
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
+            .Matches("[0-9]").WithMessage("Password must contain at least one number.")
+            .Matches("[^a-zA-Z0-9]").WithMessage("Password must contain at least one special character.");
+
+        RuleFor(x => x.ConfirmPassword)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Confirm password is required.")
+            .Equal(x => x.NewPassword).WithMessage("Passwords do not match.");
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/VerifyEmail/V1/VerifyEmailEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Identity/VerifyEmail/V1/VerifyEmailEndpointV1.cs
@@ -1,0 +1,64 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Features.Identity.Commands.VerifyEmail.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Identity.VerifyEmail.V1;
+
+public class VerifyEmailEndpointV1 : Endpoint<VerifyEmailRequestV1, ApiResponse<string>>
+{
+    private readonly IMediator _mediator;
+
+    public VerifyEmailEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("v1/auth/verify-email/{token}");
+        AllowAnonymous();
+        Description(b => b
+            .WithName("VerifyEmail")
+            .Produces<ApiResponse<string>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<string>>(StatusCodes.Status400BadRequest)
+            .WithTags("Identity"));
+    }
+
+    public override async Task HandleAsync(VerifyEmailRequestV1 req, CancellationToken ct)
+    {
+        // Map the request to command
+        var command = new VerifyEmailCommandV1
+        {
+            Token = req.Token
+        };
+
+        // Send the command to the handler
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                ErrorType.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            var errorResponse = ApiResponse<string>.Failure(
+                result.Error.Message,
+                statusCode);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        // Return successful response
+        var response = ApiResponse<string>.Success(
+            "Email verification successful. You can now log in.",
+            "Email verification successful");
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Identity/VerifyEmail/V1/VerifyEmailRequestV1.cs
+++ b/Shopilent.API/Endpoints/Identity/VerifyEmail/V1/VerifyEmailRequestV1.cs
@@ -1,0 +1,6 @@
+namespace Shopilent.API.Endpoints.Identity.VerifyEmail.V1;
+
+public class VerifyEmailRequestV1
+{
+    public string Token { get; init; }
+}


### PR DESCRIPTION
- Implemented endpoints for `Register`, `Login`, `Logout`, `ForgotPassword`, `ResetPassword`, `ChangePassword`, `ResendVerification`, and `VerifyEmail`.
- Added request/response objects and corresponding validators for each endpoint.
- Integrated API design with `FastEndpoints` and `Mediator` for request handling.
- Configured response handling for success and failure scenarios, leveraging standardized `ApiResponse` models.