### PR TITLE
Add unit tests for `Catalog` commands

### DIFF
--- a/Shopilent.Application.UnitTests/Common/TestBase.cs
+++ b/Shopilent.Application.UnitTests/Common/TestBase.cs
@@ -1,0 +1,18 @@
+using Shopilent.Application.UnitTests.Testing;
+
+namespace Shopilent.Application.UnitTests.Common;
+
+/// <summary>
+/// Base class for all unit tests providing common functionality and setup
+/// </summary>
+public abstract class TestBase
+{
+    protected readonly TestFixture Fixture;
+    protected readonly CancellationToken CancellationToken;
+
+    protected TestBase()
+    {
+        Fixture = new TestFixture();
+        CancellationToken = CancellationToken.None;
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateCategoryCommandTests.cs
@@ -1,0 +1,197 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.CreateCategory.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class CreateCategoryCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public CreateCategoryCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        // services.AddTransient(sp => Fixture.GetLogger<CreateCategoryCommandV1>());
+        services.AddTransient(sp => Fixture.GetLogger<CreateCategoryCommandHandlerV1>());
+
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<CreateCategoryCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<CreateCategoryCommandV1>, CreateCategoryCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task CreateCategory_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new CreateCategoryCommandV1
+        {
+            Name = "Test Category",
+            Slug = "test-category",
+            Description = "Test category description"
+        };
+        
+        // Mock that slug doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Capture the category being added
+        Category capturedCategory = null;
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Category>(), CancellationToken))
+            .Callback<Category, CancellationToken>((c, _) => capturedCategory = c)
+            .ReturnsAsync((Category c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        
+        // Verify the category was created and saved correctly
+        Assert.NotNull(capturedCategory);
+        Assert.Equal(command.Name, capturedCategory.Name);
+        Assert.Equal(command.Slug, capturedCategory.Slug.Value);
+        Assert.Equal(command.Description, capturedCategory.Description);
+        Assert.True(capturedCategory.IsActive);
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task CreateCategory_WithDuplicateSlug_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new CreateCategoryCommandV1
+        {
+            Name = "Test Category",
+            Slug = "test-category",
+            Description = "Test category description"
+        };
+        
+        // Mock that slug already exists
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.DuplicateSlug(command.Slug).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task CreateCategory_WithParentCategory_CreatesChildCategoryCorrectly()
+    {
+        // Arrange
+        var parentId = Guid.NewGuid();
+        var command = new CreateCategoryCommandV1
+        {
+            Name = "Child Category",
+            Slug = "child-category",
+            Description = "Child category description",
+            ParentId = parentId
+        };
+        
+        // Mock that slug doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Create a parent category
+        var parentCategory = new CategoryBuilder()
+            .WithId(parentId)
+            .WithName("Parent Category")
+            .WithSlug("parent-category")
+            .Build();
+            
+        // Mock parent category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(parentId, CancellationToken))
+            .ReturnsAsync(parentCategory);
+            
+        // Capture the category being added
+        Category capturedCategory = null;
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Category>(), CancellationToken))
+            .Callback<Category, CancellationToken>((c, _) => capturedCategory = c)
+            .ReturnsAsync((Category c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(capturedCategory);
+        Assert.Equal(command.Name, capturedCategory.Name);
+        Assert.Equal(command.ParentId, capturedCategory.ParentId);
+        Assert.Equal(1, capturedCategory.Level); // Level 1 because it's a child
+        Assert.Equal("/parent-category/child-category", capturedCategory.Path);
+    }
+    
+    [Fact]
+    public async Task CreateCategory_WithInvalidParentId_ReturnsErrorResult()
+    {
+        // Arrange
+        var nonExistentParentId = Guid.NewGuid();
+        var command = new CreateCategoryCommandV1
+        {
+            Name = "Child Category",
+            Slug = "child-category",
+            Description = "Child category description",
+            ParentId = nonExistentParentId
+        };
+        
+        // Mock that slug doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock that parent category doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentParentId, CancellationToken))
+            .ReturnsAsync((Category)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(nonExistentParentId).Code, result.Error.Code);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteCategoryCommandTests.cs
@@ -1,0 +1,280 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.DeleteCategory.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class DeleteCategoryCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public DeleteCategoryCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<DeleteCategoryCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<DeleteCategoryCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<DeleteCategoryCommandV1>, DeleteCategoryCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task DeleteCategory_WithValidCategory_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Test Category")
+            .WithSlug("test-category")
+            .Build();
+            
+        var command = new DeleteCategoryCommandV1
+        {
+            Id = categoryId
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that category has no children
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetChildCategoriesAsync(categoryId, CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+            
+        // Mock that category has no products
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByCategoryAsync(categoryId, CancellationToken))
+            .ReturnsAsync(new List<ProductDto>());
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        
+        // Verify category was deleted
+        Fixture.MockCategoryWriteRepository.Verify(
+            repo => repo.DeleteAsync(category, CancellationToken),
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task DeleteCategory_WithNonExistentCategory_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var command = new DeleteCategoryCommandV1
+        {
+            Id = categoryId
+        };
+        
+        // Mock that category doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+        
+        // Verify category was not deleted
+        Fixture.MockCategoryWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<Category>(), CancellationToken),
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task DeleteCategory_WithChildCategories_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Parent Category")
+            .WithSlug("parent-category")
+            .Build();
+            
+        var command = new DeleteCategoryCommandV1
+        {
+            Id = categoryId
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that category has child categories
+        var childCategories = new List<CategoryDto>
+        {
+            new CategoryDto { Id = Guid.NewGuid(), Name = "Child Category 1" },
+            new CategoryDto { Id = Guid.NewGuid(), Name = "Child Category 2" }
+        };
+        
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetChildCategoriesAsync(categoryId, CancellationToken))
+            .ReturnsAsync(childCategories);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.CannotDeleteWithChildren.Code, result.Error.Code);
+        
+        // Verify category was not deleted
+        Fixture.MockCategoryWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<Category>(), CancellationToken),
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task DeleteCategory_WithAssociatedProducts_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Test Category")
+            .WithSlug("test-category")
+            .Build();
+            
+        var command = new DeleteCategoryCommandV1
+        {
+            Id = categoryId
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that category has no children
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetChildCategoriesAsync(categoryId, CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+            
+        // Mock that category has associated products
+        var products = new List<ProductDto>
+        {
+            new ProductDto { Id = Guid.NewGuid(), Name = "Product 1" },
+            new ProductDto { Id = Guid.NewGuid(), Name = "Product 2" }
+        };
+        
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByCategoryAsync(categoryId, CancellationToken))
+            .ReturnsAsync(products);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.CannotDeleteWithProducts.Code, result.Error.Code);
+        
+        // Verify category was not deleted
+        Fixture.MockCategoryWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<Category>(), CancellationToken),
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task DeleteCategory_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Test Category")
+            .WithSlug("test-category")
+            .Build();
+            
+        var command = new DeleteCategoryCommandV1
+        {
+            Id = categoryId
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that category has no children
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetChildCategoriesAsync(categoryId, CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+            
+        // Mock that category has no products
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByCategoryAsync(categoryId, CancellationToken))
+            .ReturnsAsync(new List<ProductDto>());
+            
+        // Make DeleteAsync throw an exception
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.DeleteAsync(category, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Category.DeleteFailed", result.Error.Code);
+        Assert.Contains("Failed to delete category", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryCommandTests.cs
@@ -1,0 +1,283 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateCategory.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateCategoryCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public UpdateCategoryCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateCategoryCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateCategoryCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateCategoryCommandV1>, UpdateCategoryCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Original Category")
+            .WithSlug("original-category")
+            .Build();
+            
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "updated-category",
+            Description = "Updated description"
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that slug doesn't exist for other categories
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, categoryId, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(categoryId, result.Value.Id);
+        Assert.Equal(command.Name, result.Value.Name);
+        Assert.Equal(command.Slug, result.Value.Slug);
+        Assert.Equal(command.Description, result.Value.Description);
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithNonExistentCategory_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "updated-category",
+            Description = "Updated description"
+        };
+        
+        // Mock that category doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithDuplicateSlug_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Original Category")
+            .WithSlug("original-category")
+            .Build();
+            
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "duplicate-slug",
+            Description = "Updated description"
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that slug exists for other categories
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, categoryId, CancellationToken))
+            .ReturnsAsync(true);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.DuplicateSlug(command.Slug).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithInvalidSlug_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "invalid slug with spaces",
+            Description = "Updated description"
+        };
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithIsActiveTrue_ActivatesCategory()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Original Category")
+            .WithSlug("original-category")
+            .IsInactive() // Create inactive category
+            .Build();
+            
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "updated-category",
+            Description = "Updated description",
+            IsActive = true // Set to active
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that slug doesn't exist for other categories
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, categoryId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value.IsActive);
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategory_WithIsActiveFalse_DeactivatesCategory()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Original Category")
+            .WithSlug("original-category")
+            .Build(); // Active by default
+            
+        var command = new UpdateCategoryCommandV1
+        {
+            Id = categoryId,
+            Name = "Updated Category",
+            Slug = "updated-category",
+            Description = "Updated description",
+            IsActive = false // Set to inactive
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock that slug doesn't exist for other categories
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, categoryId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value.IsActive);
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryParentCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryParentCommandTests.cs
@@ -1,0 +1,262 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateCategoryParent.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateCategoryParentCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public UpdateCategoryParentCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateCategoryParentCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateCategoryParentCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateCategoryParentCommandV1>, UpdateCategoryParentCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryParent_WithValidParent_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Child Category")
+            .WithSlug("child-category")
+            .Build();
+            
+        var parentCategory = new CategoryBuilder()
+            .WithId(parentId)
+            .WithName("Parent Category")
+            .WithSlug("parent-category")
+            .Build();
+            
+        var command = new UpdateCategoryParentCommandV1
+        {
+            Id = categoryId,
+            ParentId = parentId
+        };
+        
+        // Mock category retrievals
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(parentId, CancellationToken))
+            .ReturnsAsync(parentCategory);
+        
+        // Mock parent category reader for response
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetByIdAsync(parentId, CancellationToken))
+            .ReturnsAsync(new Domain.Catalog.DTOs.CategoryDto 
+            {
+                Id = parentId,
+                Name = "Parent Category"
+            });
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(categoryId, result.Value.Id);
+        Assert.Equal(parentId, result.Value.ParentId);
+        Assert.Equal("Parent Category", result.Value.ParentName);
+        Assert.Equal(1, result.Value.Level); // Level 1 as child of parent
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryParent_RemovingParent_SetsCategoryAsRoot()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var originalParentId = Guid.NewGuid();
+        
+        // Create a category with a parent
+        var parentCategory = new CategoryBuilder()
+            .WithId(originalParentId)
+            .WithName("Original Parent")
+            .WithSlug("original-parent")
+            .Build();
+            
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Child Category")
+            .WithSlug("child-category")
+            .WithParent(parentCategory)
+            .Build();
+            
+        var command = new UpdateCategoryParentCommandV1
+        {
+            Id = categoryId,
+            ParentId = null // Remove parent
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(categoryId, result.Value.Id);
+        Assert.Null(result.Value.ParentId);
+        Assert.Null(result.Value.ParentName);
+        Assert.Equal(0, result.Value.Level); // Level 0 as root category
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryParent_WithNonExistentCategory_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        
+        var command = new UpdateCategoryParentCommandV1
+        {
+            Id = categoryId,
+            ParentId = parentId
+        };
+        
+        // Mock that category doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryParent_WithNonExistentParent_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var nonExistentParentId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Child Category")
+            .WithSlug("child-category")
+            .Build();
+            
+        var command = new UpdateCategoryParentCommandV1
+        {
+            Id = categoryId,
+            ParentId = nonExistentParentId
+        };
+        
+        // Mock category retrieval but not parent
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentParentId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(nonExistentParentId).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryParent_SettingCategoryAsItsOwnParent_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Self Parent Category")
+            .WithSlug("self-parent-category")
+            .Build();
+            
+        var command = new UpdateCategoryParentCommandV1
+        {
+            Id = categoryId,
+            ParentId = categoryId // Same as category ID
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.CircularReference.Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryStatusCommandTests.cs
@@ -1,0 +1,230 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateCategoryStatus.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateCategoryStatusCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public UpdateCategoryStatusCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateCategoryStatusCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateCategoryStatusCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateCategoryStatusCommandV1>, UpdateCategoryStatusCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryStatus_ActivatingInactiveCategory_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        // Create an inactive category
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Inactive Category")
+            .WithSlug("inactive-category")
+            .IsInactive() // Set to inactive
+            .Build();
+            
+        var command = new UpdateCategoryStatusCommandV1
+        {
+            Id = categoryId,
+            IsActive = true // Activate
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(category.IsActive); // Verify category was activated
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryStatus_DeactivatingActiveCategory_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        // Create an active category
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Active Category")
+            .WithSlug("active-category")
+            .Build(); // Active by default
+            
+        var command = new UpdateCategoryStatusCommandV1
+        {
+            Id = categoryId,
+            IsActive = false // Deactivate
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.False(category.IsActive); // Verify category was deactivated
+        
+        // Verify the category was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryStatus_WithNonExistentCategory_ReturnsErrorResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var command = new UpdateCategoryStatusCommandV1
+        {
+            Id = categoryId,
+            IsActive = true
+        };
+        
+        // Mock that category doesn't exist
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+        
+        // Verify the category was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryStatus_WithSameStatus_StillSucceeds()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        // Create an active category
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Active Category")
+            .WithSlug("active-category")
+            .Build(); // Active by default
+            
+        var command = new UpdateCategoryStatusCommandV1
+        {
+            Id = categoryId,
+            IsActive = true // Already active
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(category.IsActive); // Still active
+        
+        // Verify the category was saved (even though no real change occurred)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task UpdateCategoryStatus_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        var category = new CategoryBuilder()
+            .WithId(categoryId)
+            .WithName("Test Category")
+            .WithSlug("test-category")
+            .Build();
+            
+        var command = new UpdateCategoryStatusCommandV1
+        {
+            Id = categoryId,
+            IsActive = false
+        };
+        
+        // Mock category retrieval
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Make SaveEntitiesAsync throw an exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveEntitiesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+            
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Category.UpdateStatusFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAllCategoriesQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAllCategoriesQueryHandlerTests.cs
@@ -1,0 +1,177 @@
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetAllCategories.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetAllCategoriesQueryHandlerTests : TestBase
+{
+    private readonly GetAllCategoriesQueryHandlerV1 _handler;
+
+    public GetAllCategoriesQueryHandlerTests()
+    {
+        _handler = new GetAllCategoriesQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetAllCategoriesQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingCategories_ReturnsAllCategories()
+    {
+        // Arrange
+        var query = new GetAllCategoriesQueryV1();
+
+        // Create categories of mixed types (root, child, active/inactive)
+        var categories = new List<CategoryDto>
+        {
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Root Category 1",
+                Slug = "root-category-1",
+                ParentId = null,
+                Level = 0,
+                Path = "/root-category-1",
+                IsActive = true
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Root Category 2",
+                Slug = "root-category-2",
+                ParentId = null,
+                Level = 0,
+                Path = "/root-category-2",
+                IsActive = false
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Child Category 1",
+                Slug = "child-category-1",
+                ParentId = Guid.NewGuid(),
+                Level = 1,
+                Path = "/parent-category/child-category-1",
+                IsActive = true
+            }
+        };
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(categories);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.Value.Count);
+        Assert.Contains(result.Value, c => c.Name == "Root Category 1");
+        Assert.Contains(result.Value, c => c.Name == "Root Category 2");
+        Assert.Contains(result.Value, c => c.Name == "Child Category 1");
+    }
+
+    [Fact]
+    public async Task Handle_WithNoCategories_ReturnsEmptyList()
+    {
+        // Arrange
+        var query = new GetAllCategoriesQueryV1();
+
+        // Mock empty categories list
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetAllCategoriesQueryV1();
+
+        // Mock exception
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Categories.GetAllFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var query = new GetAllCategoriesQueryV1();
+        
+        // Mock successful repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+
+        // Act - no need to actually check the result here
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert that cache settings are properly configured
+        Assert.Equal("all-categories", query.CacheKey);
+        Assert.NotNull(query.Expiration);
+        Assert.Equal(TimeSpan.FromMinutes(30), query.Expiration);
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesFilteringIsNotApplied()
+    {
+        // Arrange
+        var query = new GetAllCategoriesQueryV1();
+        
+        // Create mixed categories
+        var allCategories = new List<CategoryDto>
+        {
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Active Category",
+                IsActive = true
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Inactive Category",
+                IsActive = false
+            }
+        };
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(allCategories);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert - ensure both active and inactive categories are returned
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Count);
+        Assert.Contains(result.Value, c => c.Name == "Active Category");
+        Assert.Contains(result.Value, c => c.Name == "Inactive Category");
+        
+        // Verify we're using ListAllAsync and not filtering by activity status
+        Fixture.MockCategoryReadRepository.Verify(
+            repo => repo.ListAllAsync(CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetCategoriesDatatableQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetCategoriesDatatableQueryHandlerTests.cs
@@ -1,0 +1,281 @@
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetCategoriesDatatable.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetCategoriesDatatableQueryHandlerTests : TestBase
+{
+    private readonly GetCategoriesDatatableQueryHandlerV1 _handler;
+
+    public GetCategoriesDatatableQueryHandlerTests()
+    {
+        _handler = new GetCategoriesDatatableQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetCategoriesDatatableQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_ReturnsFormattedDatatableResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10,
+            Search = new DataTableSearch { Value = "test" },
+            Order = new List<DataTableOrder>
+            {
+                new DataTableOrder { Column = 0, Dir = "asc" }
+            },
+            Columns = new List<DataTableColumn>
+            {
+                new DataTableColumn { Data = "name", Name = "Name", Searchable = true, Orderable = true }
+            }
+        };
+
+        var query = new GetCategoriesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        // Create categories with parent relationships
+        var parentId1 = Guid.NewGuid();
+        var parentId2 = Guid.NewGuid();
+
+        // Use CategoryDetailDto instead of CategoryDto
+        var categories = new List<CategoryDetailDto>
+        {
+            new CategoryDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Category 1",
+                Slug = "test-category-1",
+                Description = "Test description 1",
+                ParentId = parentId1,
+                ParentName = "Parent Category 1", // Set directly in the DTO
+                Level = 1,
+                IsActive = true,
+                ProductCount = 2, // Set directly in the DTO
+                CreatedAt = DateTime.UtcNow.AddDays(-5),
+                UpdatedAt = DateTime.UtcNow.AddDays(-2)
+            },
+            new CategoryDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Category 2",
+                Slug = "test-category-2",
+                Description = "Test description 2",
+                ParentId = parentId2,
+                ParentName = "Parent Category 2", // Set directly in the DTO
+                Level = 1,
+                IsActive = false,
+                ProductCount = 1, // Set directly in the DTO
+                CreatedAt = DateTime.UtcNow.AddDays(-3),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            }
+        };
+
+        // Setup the datatable result with CategoryDetailDto
+        var dataTableResult = new DataTableResult<CategoryDetailDto>(
+            draw: 1,
+            recordsTotal: 25,
+            recordsFiltered: 2,
+            data: categories
+        );
+
+        // Mock the repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetCategoryDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(dataTableResult);
+
+        // No need to mock parent category retrieval since we're using CategoryDetailDto with ParentName already set
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify datatable metadata
+        Assert.Equal(1, result.Value.Draw);
+        Assert.Equal(25, result.Value.RecordsTotal);
+        Assert.Equal(2, result.Value.RecordsFiltered);
+        Assert.Equal(2, result.Value.Data.Count);
+
+        // Verify the CategoryDatatableDto properties
+        var firstCategory = result.Value.Data.First(c => c.Name == "Test Category 1");
+        Assert.Equal(categories[0].Id, firstCategory.Id);
+        Assert.Equal("test-category-1", firstCategory.Slug);
+        Assert.Equal("Test description 1", firstCategory.Description);
+        Assert.Equal(parentId1, firstCategory.ParentId);
+        Assert.Equal("Parent Category 1", firstCategory.ParentName);
+        Assert.Equal(1, firstCategory.Level);
+        Assert.True(firstCategory.IsActive);
+        Assert.Equal(2, firstCategory.ProductCount);
+
+        var secondCategory = result.Value.Data.First(c => c.Name == "Test Category 2");
+        Assert.Equal(categories[1].Id, secondCategory.Id);
+        Assert.Equal("test-category-2", secondCategory.Slug);
+        Assert.Equal("Test description 2", secondCategory.Description);
+        Assert.Equal(parentId2, secondCategory.ParentId);
+        Assert.Equal("Parent Category 2", secondCategory.ParentName);
+        Assert.Equal(1, secondCategory.Level);
+        Assert.False(secondCategory.IsActive);
+        Assert.Equal(1, secondCategory.ProductCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithMissingParentCategories_HandlesGracefully()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10,
+            Search = new DataTableSearch { Value = "" },
+            Order = new List<DataTableOrder>
+            {
+                new DataTableOrder { Column = 0, Dir = "asc" }
+            },
+            Columns = new List<DataTableColumn>
+            {
+                new DataTableColumn { Data = "name", Name = "Name", Searchable = true, Orderable = true }
+            }
+        };
+
+        var query = new GetCategoriesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        // Create category with non-existent parent
+        var nonExistentParentId = Guid.NewGuid();
+        var categories = new List<CategoryDetailDto>
+        {
+            new CategoryDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Orphan Category",
+                Slug = "orphan-category",
+                ParentId = nonExistentParentId,
+                ParentName = null, // No parent name
+                Level = 1,
+                IsActive = true,
+                ProductCount = 0 // No products
+            }
+        };
+
+        var dataTableResult = new DataTableResult<CategoryDetailDto>(
+            draw: 1,
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            data: categories
+        );
+
+        // Mock the repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetCategoryDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(dataTableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.Data.Count);
+
+        var categoryDto = result.Value.Data.First();
+        Assert.Equal("Orphan Category", categoryDto.Name);
+        Assert.Equal(nonExistentParentId, categoryDto.ParentId);
+        Assert.Null(categoryDto.ParentName); // Parent name should be null
+        Assert.Equal(0, categoryDto.ProductCount); // No products
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetCategoriesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        // Mock exception
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetCategoryDetailDataTableAsync(request, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Categories.GetDataTableFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithNullDataTableRequest_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var query = new GetCategoriesDatatableQueryV1
+        {
+            Request = null
+        };
+
+        // Act & Assert
+        // Using await Assert.ThrowsAsync instead of just Assert.ThrowsAsync
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await _handler.Handle(query, CancellationToken));
+    }
+
+    [Fact]
+    public async Task Handle_WithZeroDraw_ReturnsCorrectDrawNumber()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 0, // Zero draw number should be preserved
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetCategoriesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var dataTableResult = new DataTableResult<CategoryDetailDto>(
+            draw: 0,
+            recordsTotal: 0,
+            recordsFiltered: 0,
+            data: new List<CategoryDetailDto>()
+        );
+
+        // Mock the repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetCategoryDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(dataTableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value.Draw); // Draw number should be preserved
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetCategoryQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetCategoryQueryHandlerTests.cs
@@ -1,0 +1,98 @@
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetCategory.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetCategoryQueryHandlerTests : TestBase
+{
+    private readonly GetCategoryQueryHandlerV1 _handler;
+    
+    public GetCategoryQueryHandlerTests()
+    {
+        _handler = new GetCategoryQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetCategoryQueryHandlerV1>());
+    }
+    
+    [Fact]
+    public async Task Handle_WithValidCategoryId_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        var categoryDto = new CategoryDto
+        {
+            Id = categoryId,
+            Name = "Test Category",
+            Slug = "test-category",
+            Description = "Test category description",
+            ParentId = null,
+            Level = 0,
+            Path = "/test-category",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(categoryDto);
+            
+        var query = new GetCategoryQueryV1 { Id = categoryId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(categoryId, result.Value.Id);
+        Assert.Equal(categoryDto.Name, result.Value.Name);
+        Assert.Equal(categoryDto.Slug, result.Value.Slug);
+    }
+    
+    [Fact]
+    public async Task Handle_WithInvalidCategoryId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync((CategoryDto)null);
+            
+        var query = new GetCategoryQueryV1 { Id = categoryId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound(categoryId).Code, result.Error.Code);
+    }
+    
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var categoryId = Guid.NewGuid();
+        
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+            
+        var query = new GetCategoryQueryV1 { Id = categoryId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Category.GetFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetPaginatedCategoriesQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetPaginatedCategoriesQueryHandlerTests.cs
@@ -1,0 +1,469 @@
+// using Moq;
+// using Shopilent.Application.Features.Catalog.Queries.GetPaginatedCategories.V1;
+// using Shopilent.Application.UnitTests.Common;
+// using Shopilent.Domain.Catalog.DTOs;
+// using Shopilent.Domain.Common.Models;
+// using Shopilent.Domain.Common.Results;
+// using Xunit;
+//
+// namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+//
+// public class GetPaginatedCategoriesQueryHandlerTests : TestBase
+// {
+//     private readonly GetPaginatedCategoriesQueryHandlerV1 _handler;
+//
+//     public GetPaginatedCategoriesQueryHandlerTests()
+//     {
+//         _handler = new GetPaginatedCategoriesQueryHandlerV1(
+//             Fixture.MockUnitOfWork.Object,
+//             Fixture.GetLogger<GetPaginatedCategoriesQueryHandlerV1>());
+//     }
+//
+//     [Fact]
+//     public async Task Handle_WithDefaultParameters_ReturnsPaginatedCategories()
+//     {
+//         // Arrange
+//         var query = new GetPaginatedCategoriesQueryV1
+//         {
+//             // Default values:
+//             // PageNumber = 1
+//             // PageSize = 10
+//             // SortColumn = "Name"
+//             // SortDescending = false
+//         };
+//
+//         // Create a paginated result with some categories
+//         var categories = new List<CategoryDto>
+//         {
+//             new CategoryDto
+//             {
+//                 Id = Guid.NewGuid(),
+//                 Name = "Category A",
+//                 Slug = "category-a",
+//                 Level = 0
+//             },
+//             new CategoryDto
+//             {
+//                 Id = Guid.NewGuid(),
+//                 Name = "Category B",
+//                 Slug = "category-b",
+//                 Level = 0
+//             }
+//         };
+//
+//         var paginatedResult = new PaginatedResult<CategoryDto>(
+//             pageNumber: 1,
+//             pageSize: 10,
+//             totalCount: 2,
+//             totalPages: 1,
+//             items: categories
+//         );
+//
+//         Fixture.MockCategoryReadRepository
+//             .Setup(repo => repo.GetPaginatedAsync(
+//                 1, 10, "Name", false, CancellationToken))
+//             .ReturnsAsync(paginatedResult);
+//
+//         // Act
+//         var result = await _handler.Handle(query, CancellationToken);
+//
+//         // Assert
+//         Assert.True(result.IsSuccess);
+//         Assert.Equal(1, result.Value.PageNumber);
+//         Assert.Equal(10, result.Value.PageSize);
+//         Assert.Equal(2, result.Value.TotalCount);
+//         Assert.Equal(1, result.Value.TotalPages);
+//         Assert.Equal(2, result.Value.Items.Count);
+//         Assert.Contains(result.Value.Items, c => c.Name == "Category A");
+//         Assert.Contains(result.Value.Items, c => c.Name == "Category B");
+//     }
+//
+//     [Fact]
+//     public async Task Handle_WithCustomParameters_ReturnsPaginatedCategories()
+//     {
+//         // Arrange
+//         var query = new GetPaginatedCategoriesQueryV1
+//         {
+//             PageNumber = 2,
+//             PageSize = 5,
+//             SortColumn = "Slug",
+//             SortDescending = true
+//         };
+//
+//         // Create a paginated result with some categories
+//         var categories = new List<CategoryDto>
+//         {
+//             new CategoryDto
+//             {
+//                 Id = Guid.NewGuid(),
+//                 Name = "Category C",
+//                 Slug = "category-c",
+//                 Level = 0
+//             },
+//             new CategoryDto
+//             {
+//                 Id = Guid.NewGuid(),
+//                 Name = "Category D",
+//                 Slug = "category-d",
+//                 Level = 0
+//             }
+//         };
+//
+//         var paginatedResult = new PaginatedResult<CategoryDto>(
+//             pageNumber: 2,
+//             pageSize: 5,
+//             totalCount: 10,
+//             totalPages: 2,
+//             items: categories
+//         );
+//
+//         Fixture.MockCategoryReadRepository
+//             .Setup(repo => repo.GetPaginatedAsync(
+//                 2, 5, "Slug", true, CancellationToken))
+//             .ReturnsAsync(paginatedResult);
+//
+//         // Act
+//         var result = await _handler.Handle(query, CancellationToken);
+//
+//         // Assert
+//         Assert.True(result.IsSuccess);
+//         Assert.Equal(2, result.Value.PageNumber);
+//         Assert.Equal(5, result.Value.PageSize);
+//         Assert.Equal(10, result.Value.TotalCount);
+//         Assert.Equal(2, result.Value.TotalPages);
+//         Assert.Equal(2, result.Value.Items.Count);
+//         
+//         // Verify parameters were passed correctly
+//         Fixture.MockCategoryReadRepository.Verify(
+//             repo => repo.GetPaginatedAsync(
+//                 2, 5, "Slug", true, CancellationToken),
+//             Times.Once);
+//     }
+//
+//     [Fact]
+//     public async Task Handle_WithEmptyPage_ReturnsEmptyItemsList()
+//     {
+//         // Arrange
+//         var query = new GetPaginatedCategoriesQueryV1
+//         {
+//             PageNumber = 3, // Page beyond available data
+//             PageSize = 10
+//         };
+//
+//         // Create an empty paginated result
+//         var paginatedResult = new PaginatedResult<CategoryDto>(
+//             pageNumber: 3,
+//             pageSize: 10,
+//             totalCount: 15, // 15 total items, but none on page 3 with pageSize 10
+//             totalPages: 2,
+//             items: new List<CategoryDto>() // Empty items
+//         );
+//
+//         Fixture.MockCategoryReadRepository
+//             .Setup(repo => repo.GetPaginatedAsync(
+//                 3, 10, "Name", false, CancellationToken))
+//             .ReturnsAsync(paginatedResult);
+//
+//         // Act
+//         var result = await _handler.Handle(query, CancellationToken);
+//
+//         // Assert
+//         Assert.True(result.IsSuccess);
+//         Assert.Equal(3, result.Value.PageNumber);
+//         Assert.Equal(10, result.Value.PageSize);
+//         Assert.Equal(15, result.Value.TotalCount);
+//         Assert.Equal(2, result.Value.TotalPages);
+//         Assert.Empty(result.Value.Items);
+//     }
+//
+//     [Fact]
+//     public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+//     {
+//         // Arrange
+//         var query = new GetPaginatedCategoriesQueryV1();
+//
+//         // Mock exception
+//         Fixture.MockCategoryReadRepository
+//             .Setup(repo => repo.GetPaginatedAsync(
+//                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), CancellationToken))
+//             .ThrowsAsync(new Exception("Test exception"));
+//
+//         // Act
+//         var result = await _handler.Handle(query, CancellationToken);
+//
+//         // Assert
+//         Assert.False(result.IsSuccess);
+//         Assert.Equal("Categories.GetPaginatedFailed", result.Error.Code);
+//         Assert.Contains("Test exception", result.Error.Message);
+//     }
+//     
+//     [Fact]
+//     public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+//     {
+//         // Arrange
+//         var query = new GetPaginatedCategoriesQueryV1
+//         {
+//             PageNumber = 2,
+//             PageSize = 15,
+//             SortColumn = "CreatedAt",
+//             SortDescending = true
+//         };
+//         
+//         // Create paginated result
+//         var paginatedResult = new PaginatedResult<CategoryDto>(
+//             pageNumber: 2,
+//             pageSize: 15,
+//             totalCount: 30,
+//             totalPages: 2,
+//             items: new List<CategoryDto>()
+//         );
+//         
+//         // Mock successful repository call
+//         Fixture.MockCategoryReadRepository
+//             .Setup(repo => repo.GetPaginatedAsync(
+//                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), CancellationToken))
+//             .ReturnsAsync(paginatedResult);
+//
+//         // Act - no need to actually check the result here
+//         await _handler.Handle(query, CancellationToken);
+//
+//         // Assert that cache settings are properly configured with query parameters
+//         Assert.Equal($"categories-page-{query.PageNumber}-size-{query.PageSize}-sort-{query.SortColumn}-{query.SortDescending}", 
+//             query.CacheKey);
+//         Assert.NotNull(query.Expiration);
+//         Assert.Equal(TimeSpan.FromMinutes(15), query.Expiration);
+//     }
+// }
+
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetPaginatedCategories.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetPaginatedCategoriesQueryHandlerTests : TestBase
+{
+    private readonly GetPaginatedCategoriesQueryHandlerV1 _handler;
+
+    public GetPaginatedCategoriesQueryHandlerTests()
+    {
+        _handler = new GetPaginatedCategoriesQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetPaginatedCategoriesQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithDefaultParameters_ReturnsPaginatedCategories()
+    {
+        // Arrange
+        var query = new GetPaginatedCategoriesQueryV1
+        {
+            // Default values:
+            // PageNumber = 1
+            // PageSize = 10
+            // SortColumn = "Name"
+            // SortDescending = false
+        };
+
+        // Create a paginated result with some categories
+        var categories = new List<CategoryDto>
+        {
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Category A",
+                Slug = "category-a",
+                Level = 0
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Category B",
+                Slug = "category-b",
+                Level = 0
+            }
+        };
+
+        var paginatedResult = new PaginatedResult<CategoryDto>(
+            items: categories,
+            count: 2,
+            pageNumber: 1,
+            pageSize: 10
+        );
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetPaginatedAsync(
+                1, 10, "Name", false, CancellationToken))
+            .ReturnsAsync(paginatedResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.PageNumber);
+        Assert.Equal(10, result.Value.PageSize);
+        Assert.Equal(2, result.Value.TotalCount);
+        Assert.Equal(1, result.Value.TotalPages);
+        Assert.Equal(2, result.Value.Items.Count);
+        Assert.Contains(result.Value.Items, c => c.Name == "Category A");
+        Assert.Contains(result.Value.Items, c => c.Name == "Category B");
+    }
+
+    [Fact]
+    public async Task Handle_WithCustomParameters_ReturnsPaginatedCategories()
+    {
+        // Arrange
+        var query = new GetPaginatedCategoriesQueryV1
+        {
+            PageNumber = 2,
+            PageSize = 5,
+            SortColumn = "Slug",
+            SortDescending = true
+        };
+
+        // Create a paginated result with some categories
+        var categories = new List<CategoryDto>
+        {
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Category C",
+                Slug = "category-c",
+                Level = 0
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Category D",
+                Slug = "category-d",
+                Level = 0
+            }
+        };
+
+        var paginatedResult = new PaginatedResult<CategoryDto>(
+            items: categories,
+            count: 10,
+            pageNumber: 2,
+            pageSize: 5
+        );
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetPaginatedAsync(
+                2, 5, "Slug", true, CancellationToken))
+            .ReturnsAsync(paginatedResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.PageNumber);
+        Assert.Equal(5, result.Value.PageSize);
+        Assert.Equal(10, result.Value.TotalCount);
+        Assert.Equal(2, result.Value.TotalPages);
+        Assert.Equal(2, result.Value.Items.Count);
+        
+        // Verify parameters were passed correctly
+        Fixture.MockCategoryReadRepository.Verify(
+            repo => repo.GetPaginatedAsync(
+                2, 5, "Slug", true, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyPage_ReturnsEmptyItemsList()
+    {
+        // Arrange
+        var query = new GetPaginatedCategoriesQueryV1
+        {
+            PageNumber = 3, // Page beyond available data
+            PageSize = 10
+        };
+
+        // Create an empty paginated result
+        var paginatedResult = new PaginatedResult<CategoryDto>(
+            items: new List<CategoryDto>(), // Empty items
+            count: 15, // 15 total items, but none on page 3 with pageSize 10
+            pageNumber: 3,
+            pageSize: 10
+        );
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetPaginatedAsync(
+                3, 10, "Name", false, CancellationToken))
+            .ReturnsAsync(paginatedResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.Value.PageNumber);
+        Assert.Equal(10, result.Value.PageSize);
+        Assert.Equal(15, result.Value.TotalCount);
+        Assert.Equal(2, result.Value.TotalPages);
+        Assert.Empty(result.Value.Items);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetPaginatedCategoriesQueryV1();
+
+        // Mock exception
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetPaginatedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Categories.GetPaginatedFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var query = new GetPaginatedCategoriesQueryV1
+        {
+            PageNumber = 2,
+            PageSize = 15,
+            SortColumn = "CreatedAt",
+            SortDescending = true
+        };
+        
+        // Create paginated result
+        var paginatedResult = new PaginatedResult<CategoryDto>(
+            items: new List<CategoryDto>(),
+            count: 30,
+            pageNumber: 2,
+            pageSize: 15
+        );
+        
+        // Mock successful repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetPaginatedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), CancellationToken))
+            .ReturnsAsync(paginatedResult);
+
+        // Act - no need to actually check the result here
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert that cache settings are properly configured with query parameters
+        Assert.Equal($"categories-page-{query.PageNumber}-size-{query.PageSize}-sort-{query.SortColumn}-{query.SortDescending}", 
+            query.CacheKey);
+        Assert.NotNull(query.Expiration);
+        Assert.Equal(TimeSpan.FromMinutes(15), query.Expiration);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetRootCategoriesQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetRootCategoriesQueryHandlerTests.cs
@@ -1,0 +1,131 @@
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetRootCategories.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetRootCategoriesQueryHandlerTests : TestBase
+{
+    private readonly GetRootCategoriesQueryHandlerV1 _handler;
+
+    public GetRootCategoriesQueryHandlerTests()
+    {
+        _handler = new GetRootCategoriesQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetRootCategoriesQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingRootCategories_ReturnsCategories()
+    {
+        // Arrange
+        var query = new GetRootCategoriesQueryV1();
+
+        // Create root categories
+        var rootCategories = new List<CategoryDto>
+        {
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Root Category 1",
+                Slug = "root-category-1",
+                ParentId = null,
+                Level = 0,
+                Path = "/root-category-1",
+                IsActive = true
+            },
+            new CategoryDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Root Category 2",
+                Slug = "root-category-2",
+                ParentId = null,
+                Level = 0,
+                Path = "/root-category-2",
+                IsActive = true
+            }
+        };
+
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetRootCategoriesAsync(CancellationToken))
+            .ReturnsAsync(rootCategories);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Count);
+        Assert.Contains(result.Value, c => c.Name == "Root Category 1");
+        Assert.Contains(result.Value, c => c.Name == "Root Category 2");
+        
+        // Verify all categories are actually root categories (level 0, null parent)
+        Assert.All(result.Value, c => 
+        {
+            Assert.Equal(0, c.Level);
+            Assert.Null(c.ParentId);
+        });
+    }
+
+    [Fact]
+    public async Task Handle_WithNoRootCategories_ReturnsEmptyList()
+    {
+        // Arrange
+        var query = new GetRootCategoriesQueryV1();
+
+        // Mock empty root categories list
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetRootCategoriesAsync(CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetRootCategoriesQueryV1();
+
+        // Mock exception
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetRootCategoriesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Categories.GetRootCategoriesFailed", result.Error.Code);
+        Assert.Contains("Test exception", result.Error.Message);
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var query = new GetRootCategoriesQueryV1();
+        
+        // Mock successful repository call
+        Fixture.MockCategoryReadRepository
+            .Setup(repo => repo.GetRootCategoriesAsync(CancellationToken))
+            .ReturnsAsync(new List<CategoryDto>());
+
+        // Act - no need to actually check the result here
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert that cache settings are properly configured
+        Assert.Equal("root-categories", query.CacheKey);
+        Assert.NotNull(query.Expiration);
+        Assert.Equal(TimeSpan.FromMinutes(30), query.Expiration);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/ChangePasswordCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/ChangePasswordCommandTests.cs
@@ -1,0 +1,298 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.ChangePassword.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class ChangePasswordCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ChangePasswordCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ChangePasswordCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Mock successful password change
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ChangePasswordAsync(
+                userId,
+                command.CurrentPassword,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct parameters
+        Fixture.MockAuthenticationService.Verify(auth => auth.ChangePasswordAsync(
+            userId,
+            command.CurrentPassword,
+            command.NewPassword,
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithPasswordMismatch_ReturnsErrorResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "DifferentPassword789!" // Different from NewPassword
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.PasswordMismatch", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.ChangePasswordAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithInvalidCurrentPassword_ReturnsErrorResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "WrongPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Mock auth service to return invalid credentials error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ChangePasswordAsync(
+                userId,
+                command.CurrentPassword,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(UserErrors.InvalidCredentials));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithSameNewAndCurrentPassword_ReturnsValidationError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var password = "Password123!";
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = password,
+            NewPassword = password, // Same as current
+            ConfirmPassword = password
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.ChangePasswordAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWeakNewPassword_ReturnsValidationError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "weak", // Too weak
+            ConfirmPassword = "weak"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.PasswordTooShort.Code, result.Error.Code);
+
+        // Check for multiple password validation errors
+        // Assert.NotNull(result.Error.Metadata);
+        // Assert.Contains("NewPassword", result.Error.Metadata.Keys);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.ChangePasswordAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithEmptyUserId_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = Guid.Empty, // Empty UserId
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify metadata contains user id validation error
+        Assert.NotNull(result.Error.Metadata);
+        Assert.Contains("UserId", result.Error.Metadata.Keys);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.ChangePasswordAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithEmptyCurrentPassword_ReturnsValidationError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "", // Empty current password
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.PasswordRequired.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ChangePasswordAsync(
+                userId,
+                command.CurrentPassword,
+                command.NewPassword,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ChangePassword.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithUserNotFound_ReturnsErrorResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new ChangePasswordCommandV1
+        {
+            UserId = userId,
+            CurrentPassword = "OldPassword123!",
+            NewPassword = "NewPassword456!",
+            ConfirmPassword = "NewPassword456!"
+        };
+
+        // Mock auth service to return user not found error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ChangePasswordAsync(
+                userId,
+                command.CurrentPassword,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(UserErrors.NotFound(userId)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.NotFound(userId).Code, result.Error.Code);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/ForgotPasswordCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/ForgotPasswordCommandTests.cs
@@ -1,0 +1,184 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.ForgotPassword.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class ForgotPasswordCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ForgotPasswordCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ForgotPasswordCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WithValidEmail_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock successful password reset request
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RequestPasswordResetAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct email
+        Fixture.MockAuthenticationService.Verify(auth => auth.RequestPasswordResetAsync(
+            It.Is<Email>(e => e.Value == command.Email),
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WithInvalidEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = "invalid-email"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.InvalidEmailFormat", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.RequestPasswordResetAsync(
+            It.IsAny<Email>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WithEmptyEmail_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = ""
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.EmailRequired.Code, result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(auth => auth.RequestPasswordResetAsync(
+            It.IsAny<Email>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WithNonExistentEmail_ReturnsSuccessAnyway()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = "nonexistent@example.com"
+        };
+
+        // Mock auth service to return user not found, but this should not
+        // be exposed to the client for security reasons
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RequestPasswordResetAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Success()); // Still returns success to prevent user enumeration
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Even though user doesn't exist, we should still call the service
+        // and return success to prevent user enumeration attacks
+        Fixture.MockAuthenticationService.Verify(auth => auth.RequestPasswordResetAsync(
+            It.Is<Email>(e => e.Value == command.Email),
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WhenEmailSendingFails_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock auth service to return email sending error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RequestPasswordResetAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Failure(
+                code: "Email.SendingFailed",
+                message: "Failed to send email")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Email.SendingFailed", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new ForgotPasswordCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RequestPasswordResetAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ForgotPassword.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/LoginCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/LoginCommandTests.cs
@@ -1,0 +1,372 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.Login.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class LoginCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public LoginCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<LoginCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Login_WithValidCredentials_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = null,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful login
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedResponse.AccessToken, result.Value.AccessToken);
+        Assert.Equal(expectedResponse.RefreshToken, result.Value.RefreshToken);
+
+        // Verify that the Authentication service was called with the correct parameters
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.LoginAsync(
+                It.Is<Email>(e => e.Value == command.Email),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "invalid-email",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify metadata contains email validation error
+        Assert.NotNull(result.Error.Metadata);
+        Assert.Contains("Email", result.Error.Metadata.Keys);
+
+        // Verify that the Authentication service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidCredentials_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "WrongPassword",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to return invalid credentials error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(UserErrors.InvalidCredentials));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Login_WithEmptyEmail_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.EmailRequired", result.Error.Code);
+        Assert.Contains("Email cannot be empty.", result.Error.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithEmptyPassword_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.PasswordRequired", result.Error.Code);
+        Assert.Contains("Password hash cannot be empty.", result.Error.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithInactiveAccount_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "inactive@example.com",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to return inactive account error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(UserErrors.AccountInactive));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.AccountInactive.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Login_WithUnverifiedEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "unverified@example.com",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to return unverified email error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(UserErrors.EmailNotVerified));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.EmailNotVerified.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Login_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Login.Failed", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Login_WithSuccessfulAuthentication_VerifiesUserData()
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Create a proper user object
+        var email = Email.Create(command.Email).Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = user,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful login with user data
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedResponse.AccessToken, result.Value.AccessToken);
+        Assert.Equal(expectedResponse.RefreshToken, result.Value.RefreshToken);
+        Assert.NotNull(result.Value.User);
+        Assert.Same(user, result.Value.User);
+        Assert.Equal(command.Email, result.Value.User.Email.Value);
+        Assert.Equal("John", result.Value.User.FullName.FirstName);
+        Assert.Equal("Doe", result.Value.User.FullName.LastName);
+    }
+
+    [Theory]
+    [InlineData(null, "Test User Agent")]
+    [InlineData("127.0.0.1", null)]
+    [InlineData(null, null)]
+    public async Task Login_WithMissingIpOrUserAgent_StillPassesParameters(string ipAddress, string userAgent)
+    {
+        // Arrange
+        var command = new LoginCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            IpAddress = ipAddress,
+            UserAgent = userAgent
+        };
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = null,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful login
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify the auth service was called with exactly the provided parameters
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.LoginAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                ipAddress,
+                userAgent,
+                CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/LogoutCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/LogoutCommandTests.cs
@@ -1,0 +1,201 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.Logout.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class LogoutCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public LogoutCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<LogoutCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Logout_WithValidRefreshToken_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "valid-refresh-token",
+            Reason = "User logged out"
+        };
+
+        // Mock successful token revocation
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct parameters
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Logout_WithEmptyRefreshToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "",
+            Reason = "User logged out"
+        };
+
+        // Mock auth service to return empty token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(RefreshTokenErrors.EmptyToken));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.EmptyToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Logout_WithNonExistentToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "non-existent-token",
+            Reason = "User logged out"
+        };
+
+        // Mock auth service to return token not found error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(RefreshTokenErrors.NotFound(command.RefreshToken)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.NotFound(command.RefreshToken).Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Logout_WithAlreadyRevokedToken_ReturnsSuccessResult()
+    {
+        // Arrange
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "already-revoked-token",
+            Reason = "User logged out"
+        };
+
+        // Mock auth service to return already revoked error which should be handled gracefully
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(RefreshTokenErrors.AlreadyRevoked));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.AlreadyRevoked.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Logout_WithCustomReason_PassesReasonCorrectly()
+    {
+        // Arrange
+        var customReason = "User is switching devices";
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "valid-refresh-token",
+            Reason = customReason
+        };
+
+        // Mock successful token revocation
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                customReason,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with the custom reason
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                customReason,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Logout_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new LogoutCommandV1
+        {
+            RefreshToken = "valid-refresh-token",
+            Reason = "User logged out"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RevokeTokenAsync(
+                command.RefreshToken,
+                command.Reason,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Logout.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/RefreshTokenCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/RefreshTokenCommandTests.cs
@@ -1,0 +1,306 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.RefreshToken.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class RefreshTokenCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public RefreshTokenCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<RefreshTokenCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithValidToken_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "valid-refresh-token",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Create a proper user object
+        var email = Email.Create("user@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = user,
+            AccessToken = "new-access-token",
+            RefreshToken = "new-refresh-token"
+        };
+
+        // Mock successful token refresh
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedResponse.AccessToken, result.Value.AccessToken);
+        Assert.Equal(expectedResponse.RefreshToken, result.Value.RefreshToken);
+        Assert.Same(user, result.Value.User);
+
+        // Verify auth service was called with correct parameters
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithEmptyToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock validation failure for empty token
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(RefreshTokenErrors.EmptyToken));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.EmptyToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithNonExistentToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var nonExistentToken = "non-existent-token";
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = nonExistentToken,
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock token not found
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(RefreshTokenErrors.NotFound(nonExistentToken)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.NotFound(nonExistentToken).Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithExpiredToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "expired-token",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock expired token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(RefreshTokenErrors.Expired));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.Expired.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithRevokedToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "revoked-token",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        var reason = "User logged out";
+
+        // Mock revoked token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(RefreshTokenErrors.Revoked(reason)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(RefreshTokenErrors.Revoked(reason).Code, result.Error.Code);
+        Assert.Contains(reason, result.Error.Message);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithInactiveUser_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "valid-token-inactive-user",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock inactive user error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(UserErrors.AccountInactive));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.AccountInactive.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "valid-token",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("RefreshToken.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "Test User Agent")]
+    [InlineData("127.0.0.1", null)]
+    [InlineData(null, null)]
+    public async Task RefreshToken_WithMissingIpOrUserAgent_StillSucceeds(string ipAddress, string userAgent)
+    {
+        // Arrange
+        var command = new RefreshTokenCommandV1
+        {
+            RefreshToken = "valid-refresh-token",
+            IpAddress = ipAddress,
+            UserAgent = userAgent
+        };
+
+        // Create a proper user object
+        var email = Email.Create("user@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = user,
+            AccessToken = "new-access-token",
+            RefreshToken = "new-refresh-token"
+        };
+
+        // Mock successful token refresh
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                ipAddress,
+                userAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with the provided parameters (even if null)
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.RefreshTokenAsync(
+                command.RefreshToken,
+                ipAddress,
+                userAgent,
+                CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/RegisterCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/RegisterCommandTests.cs
@@ -1,0 +1,449 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.Register.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class RegisterCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public RegisterCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<RegisterCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Register_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "newuser@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = null,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful registration
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                command.Phone,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedResponse.AccessToken, result.Value.AccessToken);
+        Assert.Equal(expectedResponse.RefreshToken, result.Value.RefreshToken);
+
+        // Verify auth service was called with correct parameters
+        Fixture.MockAuthenticationService.Verify(auth => auth.RegisterAsync(
+            It.Is<Email>(e => e.Value == command.Email),
+            command.Password,
+            command.FirstName,
+            command.LastName,
+            command.Phone,
+            command.IpAddress,
+            command.UserAgent,
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task Register_WithNullPhone_StillSucceeds()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "newuser@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = null, // Null phone
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = null,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful registration with null phone
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                null, // Expect null phone
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with null phone
+        Fixture.MockAuthenticationService.Verify(auth => auth.RegisterAsync(
+            It.IsAny<Email>(),
+            command.Password,
+            command.FirstName,
+            command.LastName,
+            null, // Null phone
+            command.IpAddress,
+            command.UserAgent,
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task Register_WithIpAddressAndUserAgent_PassesValuesToAuthService()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "newuser@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "192.168.1.1", // Specific IP
+            UserAgent = "Custom User Agent" // Specific User Agent
+        };
+
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = null,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful registration
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                command.Phone,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify specific IP and user agent were passed
+        Fixture.MockAuthenticationService.Verify(auth => auth.RegisterAsync(
+            It.IsAny<Email>(),
+            command.Password,
+            command.FirstName,
+            command.LastName,
+            command.Phone,
+            "192.168.1.1", // Specific IP
+            "Custom User Agent", // Specific user agent
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task Register_WithInvalidEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "invalid-email",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify metadata contains email validation error
+        Assert.NotNull(result.Error.Metadata);
+        Assert.Contains("Email", result.Error.Metadata.Keys);
+
+        // Auth service should not be called for invalid input
+        Fixture.MockAuthenticationService.Verify(auth => auth.RegisterAsync(
+            It.IsAny<Email>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Register_WithDuplicateEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "existing@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to return duplicate email error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                command.Phone,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure<AuthTokenResponse>(UserErrors.EmailAlreadyExists(command.Email)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.EmailAlreadyExists(command.Email).Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Register_WithInvalidPassword_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "newuser@example.com",
+            Password = "weak", // Too weak password
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.PasswordTooShort.Code, result.Error.Code);
+
+        // Check multiple password validation errors in metadata
+        // Assert.NotNull(result.Error.Metadata);
+        // Assert.Contains("Password", result.Error.Metadata.Keys);
+        // var passwordErrors = result.Error.Metadata["Password"];
+        // Assert.Contains("Password must be at least 8 characters long.", passwordErrors);
+    }
+
+    [Theory]
+    [InlineData("", "Doe")] // Empty first name
+    [InlineData("John", "")] // Empty last name
+    public async Task Register_WithEmptyNames_ReturnsValidationError(string firstName, string lastName)
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            FirstName = firstName,
+            LastName = lastName,
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        // Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Check for validation errors in metadata
+        // Assert.NotNull(result.Error.Metadata);
+        if (string.IsNullOrEmpty(firstName))
+        {
+            Assert.Equal("User.FirstNameRequired", result.Error.Code);
+        }
+
+        if (string.IsNullOrEmpty(lastName))
+        {
+            // Assert.Contains("LastName", result.Error.Metadata.Keys);
+            Assert.Contains("User.LastNameRequired", result.Error.Code);
+        }
+    }
+
+    [Fact]
+    public async Task Register_WithInvalidPhone_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "invalid-phone", // Invalid phone number
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.InvalidPhoneFormat", result.Error.Code);
+        // Assert.NotNull(result.Error.Metadata);
+        // Assert.Contains("Phone", result.Error.Metadata.Keys);
+    }
+
+    [Fact]
+    public async Task Register_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "test@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Mock authentication service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                command.Phone,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Registration.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+
+    [Fact]
+    public async Task Register_WithSuccessfulRegistration_VerifiesUserData()
+    {
+        // Arrange
+        var command = new RegisterCommandV1
+        {
+            Email = "newuser@example.com",
+            Password = "Password123!",
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        // Create a mock user with proper initialization
+        var email = Email.Create(command.Email).Value;
+        var fullName = FullName.Create(command.FirstName, command.LastName).Value;
+        var user = User.Create(email, "hashedpassword", fullName).Value;
+
+        // Create response with the user
+        var expectedResponse = new AuthTokenResponse
+        {
+            User = user,
+            AccessToken = "test-access-token",
+            RefreshToken = "test-refresh-token"
+        };
+
+        // Mock successful registration with user data
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.RegisterAsync(
+                It.IsAny<Email>(),
+                command.Password,
+                command.FirstName,
+                command.LastName,
+                command.Phone,
+                command.IpAddress,
+                command.UserAgent,
+                CancellationToken))
+            .ReturnsAsync(Result.Success(expectedResponse));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedResponse.AccessToken, result.Value.AccessToken);
+        Assert.Equal(expectedResponse.RefreshToken, result.Value.RefreshToken);
+        Assert.NotNull(result.Value.User);
+        Assert.Same(user, result.Value.User);
+        Assert.Equal(command.Email, result.Value.User.Email.Value);
+        Assert.Equal(command.FirstName, result.Value.User.FullName.FirstName);
+        Assert.Equal(command.LastName, result.Value.User.FullName.LastName);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/ResendVerificationCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/ResendVerificationCommandTests.cs
@@ -1,0 +1,207 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.ResendVerification.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class ResendVerificationCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ResendVerificationCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ResendVerificationCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task ResendVerification_WithValidEmail_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock successful email verification
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct email
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.SendEmailVerificationAsync(
+                It.Is<Email>(e => e.Value == command.Email),
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResendVerification_WithInvalidEmailFormat_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "invalid-email"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.InvalidEmailFormat", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResendVerification_WithEmptyEmail_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = ""
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.EmailRequired", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResendVerification_WithNonExistentEmail_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "nonexistent@example.com"
+        };
+
+        // Mock user not found error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(UserErrors.NotFound(Guid.Empty)));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.NotFound(Guid.Empty).Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ResendVerification_ForAlreadyVerifiedEmail_ReturnsSuccessResult()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "verified@example.com"
+        };
+
+        // Mock already verified email (the service should handle this gracefully)
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ResendVerification_WhenEmailServiceFails_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock email service failure
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Failure(
+                code: "Email.SendingFailed",
+                message: "Failed to send verification email")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Email.SendingFailed", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ResendVerification_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new ResendVerificationCommandV1
+        {
+            Email = "test@example.com"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.SendEmailVerificationAsync(
+                It.IsAny<Email>(),
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ResendVerification.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/ResetPasswordCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/ResetPasswordCommandTests.cs
@@ -1,0 +1,231 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.ResetPassword.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class ResetPasswordCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ResetPasswordCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ResetPasswordCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "valid-reset-token",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "NewPassword123!"
+        };
+
+        // Mock successful password reset
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ResetPasswordAsync(
+                command.Token,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct parameters
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.ResetPasswordAsync(
+                command.Token,
+                command.NewPassword,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithPasswordMismatch_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "valid-reset-token",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "DifferentPassword456!" // Different from NewPassword
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("User.PasswordMismatch", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.ResetPasswordAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithEmptyToken_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "NewPassword123!"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.ResetPasswordAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithWeakPassword_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "valid-reset-token",
+            NewPassword = "weak", // Too weak
+            ConfirmPassword = "weak"
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UserErrors.PasswordTooShort.Code, result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.ResetPasswordAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithInvalidToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "invalid-reset-token",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "NewPassword123!"
+        };
+
+        // Mock invalid token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ResetPasswordAsync(
+                command.Token,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Validation(
+                code: "PasswordReset.InvalidToken",
+                message: "The reset token is invalid or has expired.")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PasswordReset.InvalidToken", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WithExpiredToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "expired-reset-token",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "NewPassword123!"
+        };
+
+        // Mock expired token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ResetPasswordAsync(
+                command.Token,
+                command.NewPassword,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Validation(
+                code: "PasswordReset.ExpiredToken",
+                message: "The reset token has expired.")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PasswordReset.ExpiredToken", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ResetPassword_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new ResetPasswordCommandV1
+        {
+            Token = "valid-reset-token",
+            NewPassword = "NewPassword123!",
+            ConfirmPassword = "NewPassword123!"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.ResetPasswordAsync(
+                command.Token,
+                command.NewPassword,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ResetPassword.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/VerifyEmailCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/VerifyEmailCommandTests.cs
@@ -1,0 +1,183 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Features.Identity.Commands.VerifyEmail.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class VerifyEmailCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public VerifyEmailCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockAuthenticationService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<VerifyEmailCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task VerifyEmail_WithValidToken_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = "valid-verification-token"
+        };
+
+        // Mock successful email verification
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify auth service was called with correct token
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_WithEmptyToken_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = ""
+        };
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation.Failed", result.Error.Code);
+
+        // Verify auth service was not called
+        Fixture.MockAuthenticationService.Verify(
+            auth => auth.VerifyEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_WithInvalidToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = "invalid-verification-token"
+        };
+
+        // Mock invalid token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Validation(
+                code: "EmailVerification.InvalidToken",
+                message: "The verification token is invalid.")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("EmailVerification.InvalidToken", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_WithExpiredToken_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = "expired-verification-token"
+        };
+
+        // Mock expired token error
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken))
+            .ReturnsAsync(Result.Failure(Error.Validation(
+                code: "EmailVerification.ExpiredToken",
+                message: "The verification token has expired.")));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("EmailVerification.ExpiredToken", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_ForAlreadyVerifiedEmail_ReturnsSuccessResult()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = "token-for-verified-email"
+        };
+
+        // Mock already verified success (the service should handle this gracefully)
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new VerifyEmailCommandV1
+        {
+            Token = "valid-verification-token"
+        };
+
+        // Mock auth service to throw an exception
+        Fixture.MockAuthenticationService
+            .Setup(auth => auth.VerifyEmailAsync(
+                command.Token,
+                CancellationToken))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("VerifyEmail.Failed", result.Error.Code);
+        Assert.Contains("Unexpected error", result.Error.Message);
+    }
+}

--- a/Shopilent.Application.UnitTests/Testing/Builders/CategoryBuilder.cs
+++ b/Shopilent.Application.UnitTests/Testing/Builders/CategoryBuilder.cs
@@ -1,0 +1,136 @@
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.ValueObjects;
+
+namespace Shopilent.Application.UnitTests.Testing.Builders;
+
+/// <summary>
+/// Builder pattern for creating Category entities for tests
+/// </summary>
+public class CategoryBuilder
+{
+    private Guid _id = Guid.NewGuid();
+    private string _name = "Test Category";
+    private string _slug = "test-category";
+    private string _description = "Test category description";
+    private Guid? _parentId = null;
+    private Category _parentCategory = null;
+    private int _level = 0;
+    private string _path = "/test-category";
+    private bool _isActive = true;
+    private DateTime _createdAt = DateTime.UtcNow;
+    private DateTime _updatedAt = DateTime.UtcNow;
+
+    public CategoryBuilder WithId(Guid id)
+    {
+        _id = id;
+        return this;
+    }
+    
+    public CategoryBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+    
+    public CategoryBuilder WithSlug(string slug)
+    {
+        _slug = slug;
+        return this;
+    }
+    
+    public CategoryBuilder WithDescription(string description)
+    {
+        _description = description;
+        return this;
+    }
+    
+    public CategoryBuilder WithParent(Category parent)
+    {
+        _parentCategory = parent;
+        _parentId = parent.Id;
+        _level = parent.Level + 1;
+        _path = $"{parent.Path}/{_slug}";
+        return this;
+    }
+    
+    public CategoryBuilder WithParentId(Guid parentId)
+    {
+        _parentId = parentId;
+        _level = 1; // Assuming level 1 when just setting parent ID
+        _path = $"/unknown-parent/{_slug}";
+        return this;
+    }
+    
+    public CategoryBuilder IsInactive()
+    {
+        _isActive = false;
+        return this;
+    }
+    
+    public CategoryBuilder CreatedAt(DateTime createdAt)
+    {
+        _createdAt = createdAt;
+        return this;
+    }
+    
+    public Category Build()
+    {
+        // Create the slug value object
+        var slugResult = Slug.Create(_slug);
+        if (slugResult.IsFailure)
+            throw new InvalidOperationException($"Invalid slug: {_slug}");
+            
+        // First create the domain entity
+        var categoryResult = _parentCategory != null 
+            ? Category.Create(_name, slugResult.Value, _parentCategory)
+            : Category.Create(_name, slugResult.Value);
+            
+        if (categoryResult.IsFailure)
+            throw new InvalidOperationException($"Failed to create category: {categoryResult.Error.Message}");
+            
+        var category = categoryResult.Value;
+        
+        // Use reflection to set the ID, created date, etc.
+        SetPrivatePropertyValue(category, "Id", _id);
+        SetPrivatePropertyValue(category, "CreatedAt", _createdAt);
+        SetPrivatePropertyValue(category, "UpdatedAt", _updatedAt);
+        
+        // Add description if needed
+        if (!string.IsNullOrEmpty(_description))
+        {
+            category.Update(category.Name, category.Slug, _description);
+        }
+        
+        // Set inactive if needed
+        if (!_isActive)
+        {
+            category.Deactivate();
+        }
+        
+        return category;
+    }
+    
+    private static void SetPrivatePropertyValue<T>(object obj, string propertyName, T value)
+    {
+        var propertyInfo = obj.GetType().GetProperty(propertyName);
+        if (propertyInfo != null)
+        {
+            propertyInfo.SetValue(obj, value, null);
+        }
+        else
+        {
+            var fieldInfo = obj.GetType().GetField(propertyName, 
+                System.Reflection.BindingFlags.NonPublic | 
+                System.Reflection.BindingFlags.Instance);
+                
+            if (fieldInfo != null)
+            {
+                fieldInfo.SetValue(obj, value);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Property or field {propertyName} not found on type {obj.GetType().Name}");
+            }
+        }
+    }
+}

--- a/Shopilent.Application.UnitTests/Testing/TestFixture.cs
+++ b/Shopilent.Application.UnitTests/Testing/TestFixture.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shopilent.Application.Abstractions.Caching;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Domain.Catalog.Repositories.Read;
+using Shopilent.Domain.Catalog.Repositories.Write;
+using Shopilent.Domain.Identity.Repositories.Read;
+using Shopilent.Domain.Identity.Repositories.Write;
+
+namespace Shopilent.Application.UnitTests.Testing;
+
+/// <summary>
+/// Test fixture for setting up shared resources for unit tests
+/// </summary>
+public class TestFixture
+{
+    // Mock services
+    public Mock<IUnitOfWork> MockUnitOfWork { get; private set; }
+    public Mock<ICurrentUserContext> MockCurrentUserContext { get; private set; }
+    public Mock<ICacheService> MockCacheService { get; private set; }
+    public Mock<IAuthenticationService> MockAuthenticationService { get; private set; }
+    
+    // Mock repositories
+    public Mock<ICategoryReadRepository> MockCategoryReadRepository { get; private set; }
+    public Mock<ICategoryWriteRepository> MockCategoryWriteRepository { get; private set; }
+    public Mock<IProductReadRepository> MockProductReadRepository { get; private set; }
+    public Mock<IProductWriteRepository> MockProductWriteRepository { get; private set; }
+    public Mock<IAttributeReadRepository> MockAttributeReadRepository { get; private set; }
+    public Mock<IAttributeWriteRepository> MockAttributeWriteRepository { get; private set; }
+    public Mock<IUserReadRepository> MockUserReadRepository { get; private set; }
+    public Mock<IUserWriteRepository> MockUserWriteRepository { get; private set; }
+    
+    // Generic mocks for different logger types
+    private readonly Dictionary<Type, object> _loggers = new();
+
+    public TestFixture()
+    {
+        SetUpMocks();
+    }
+
+    private void SetUpMocks()
+    {
+        // Initialize mocks
+        MockUnitOfWork = new Mock<IUnitOfWork>();
+        MockCurrentUserContext = new Mock<ICurrentUserContext>();
+        MockCacheService = new Mock<ICacheService>();
+        MockAuthenticationService = new Mock<IAuthenticationService>();
+        
+        // Initialize repository mocks
+        MockCategoryReadRepository = new Mock<ICategoryReadRepository>();
+        MockCategoryWriteRepository = new Mock<ICategoryWriteRepository>();
+        MockProductReadRepository = new Mock<IProductReadRepository>();
+        MockProductWriteRepository = new Mock<IProductWriteRepository>();
+        MockAttributeReadRepository = new Mock<IAttributeReadRepository>();
+        MockAttributeWriteRepository = new Mock<IAttributeWriteRepository>();
+        MockUserReadRepository = new Mock<IUserReadRepository>();
+        MockUserWriteRepository = new Mock<IUserWriteRepository>();
+        
+        // Set up Unit of Work to return the repository mocks
+        MockUnitOfWork.Setup(uow => uow.CategoryReader).Returns(MockCategoryReadRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.CategoryWriter).Returns(MockCategoryWriteRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.ProductReader).Returns(MockProductReadRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.ProductWriter).Returns(MockProductWriteRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.AttributeReader).Returns(MockAttributeReadRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.AttributeWriter).Returns(MockAttributeWriteRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.UserReader).Returns(MockUserReadRepository.Object);
+        MockUnitOfWork.Setup(uow => uow.UserWriter).Returns(MockUserWriteRepository.Object);
+        
+        // Setup default save changes to return success
+        MockUnitOfWork.Setup(uow => uow.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        
+        MockUnitOfWork.Setup(uow => uow.SaveEntitiesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+            
+        // Set up basic CurrentUserContext behaviors
+        MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        MockCurrentUserContext.Setup(ctx => ctx.IsAuthenticated).Returns(false);
+    }
+
+    /// <summary>
+    /// Get a mock logger for the specified type
+    /// </summary>
+    public ILogger<T> GetLogger<T>()
+    {
+        var type = typeof(T);
+        if (!_loggers.ContainsKey(type))
+        {
+            // Create a NullLogger instead of a mocked logger
+            _loggers[type] = Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance.CreateLogger<T>();
+        }
+    
+        return (ILogger<T>)_loggers[type];
+    }
+    
+    /// <summary>
+    /// Set the current user context for tests requiring an authenticated user
+    /// </summary>
+    public void SetAuthenticatedUser(Guid userId, string email = "test@example.com", bool isAdmin = false)
+    {
+        MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns(userId);
+        MockCurrentUserContext.Setup(ctx => ctx.Email).Returns(email);
+        MockCurrentUserContext.Setup(ctx => ctx.IsAuthenticated).Returns(true);
+        MockCurrentUserContext.Setup(ctx => ctx.IsInRole("Admin")).Returns(isAdmin);
+    }
+    
+    
+}

--- a/Shopilent.Application.UnitTests/Testing/TestHelpers.cs
+++ b/Shopilent.Application.UnitTests/Testing/TestHelpers.cs
@@ -1,0 +1,27 @@
+// TestHelpers.cs in the Testing folder
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Shopilent.Application.Abstractions.Behaviors;
+
+namespace Shopilent.Application.UnitTests.Testing;
+
+public static class TestHelpers
+{
+    public static IServiceCollection AddMediatRWithValidation(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg => {
+            // Use a concrete type from the Application assembly instead of the static class
+            cfg.RegisterServicesFromAssembly(typeof(Shopilent.Application.Abstractions.Messaging.ICommand<>).Assembly);
+            
+            // Add the validation pipeline behavior
+            cfg.AddOpenBehavior(typeof(ValidationPipelineBehavior<,>));
+        });
+
+        // Register all validators from the assembly
+        services.AddValidatorsFromAssembly(
+            typeof(Shopilent.Application.Abstractions.Messaging.ICommand<>).Assembly, 
+            includeInternalTypes: true);
+
+        return services;
+    }
+}

--- a/Shopilent.Application/AssemblyInfo.cs
+++ b/Shopilent.Application/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+// In Application project: AssemblyInfo.cs
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Shopilent.Application.UnitTests")]


### PR DESCRIPTION
- Added unit tests for `CreateCategoryCommand`, `DeleteCategoryCommand`, `UpdateCategoryCommand`, and `UpdateCategoryParentCommand`.
- Ensured comprehensive test coverage for command handlers, including validation, error handling, and business rule enforcement.
- Introduced `TestBase` for shared test setup logic in `Application.UnitTests`.