### PR TITLE
Refactor Stripe webhook event handling

### DIFF
--- a/Shopilent.Infrastructure.Payments/Extensions/PaymentsServiceExtensions.cs
+++ b/Shopilent.Infrastructure.Payments/Extensions/PaymentsServiceExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Shopilent.Application.Abstractions.Payments;
 using Shopilent.Infrastructure.Payments.Abstractions;
 using Shopilent.Infrastructure.Payments.Providers.Stripe;
+using Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
 using Shopilent.Infrastructure.Payments.Services;
 using Shopilent.Infrastructure.Payments.Settings;
 
@@ -22,6 +23,18 @@ public static class PaymentsServiceExtensions
         // Register payment providers
         services.AddScoped<IPaymentProvider, StripePaymentProvider>();
         // services.AddScoped<IPaymentProvider, PayPalPaymentProvider>();
+
+        // Register Stripe webhook handlers
+        services.AddScoped<PaymentIntentSucceededHandler>();
+        services.AddScoped<PaymentIntentFailedHandler>();
+        services.AddScoped<PaymentIntentRequiresActionHandler>();
+        services.AddScoped<PaymentIntentCanceledHandler>();
+        services.AddScoped<ChargeSucceededHandler>();
+        services.AddScoped<ChargeDisputeCreatedHandler>();
+        services.AddScoped<CustomerCreatedHandler>();
+        services.AddScoped<CustomerUpdatedHandler>();
+        services.AddScoped<PaymentMethodAttachedHandler>();
+        services.AddScoped<StripeWebhookHandlerFactory>();
 
         return services;
     }

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/ChargeDisputeCreatedHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/ChargeDisputeCreatedHandler.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class ChargeDisputeCreatedHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<ChargeDisputeCreatedHandler> _logger;
+
+    public ChargeDisputeCreatedHandler(ILogger<ChargeDisputeCreatedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var dispute = stripeEvent.Data.Object as Dispute;
+        if (dispute == null)
+        {
+            result.ProcessingMessage = "Invalid Dispute data in webhook";
+            return result;
+        }
+
+        result.TransactionId = dispute.ChargeId;
+        result.EventData.Add("dispute_id", dispute.Id);
+        result.EventData.Add("dispute_reason", dispute.Reason);
+        result.EventData.Add("dispute_amount", dispute.Amount);
+        result.EventData.Add("dispute_currency", dispute.Currency);
+
+        result.OrderId = dispute.Metadata["orderId"];
+        result.ProcessingMessage = $"Dispute created for charge: {dispute.ChargeId}";
+        result.IsProcessed = true;
+
+        _logger.LogWarning("Dispute created for charge: {ChargeId}, Reason: {Reason}",
+            dispute.ChargeId, dispute.Reason);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/ChargeSucceededHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/ChargeSucceededHandler.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class ChargeSucceededHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<ChargeSucceededHandler> _logger;
+
+    public ChargeSucceededHandler(ILogger<ChargeSucceededHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var charge = stripeEvent.Data.Object as Charge;
+        if (charge == null)
+        {
+            result.ProcessingMessage = "Invalid Charge data in webhook";
+            return result;
+        }
+
+        result.TransactionId = charge.PaymentIntentId ?? charge.Id;
+        result.PaymentStatus = PaymentStatus.Succeeded;
+        result.CustomerId = charge.CustomerId;
+        result.EventData.Add("charge_id", charge.Id);
+        result.EventData.Add("payment_intent_id", charge.PaymentIntentId ?? string.Empty);
+        result.EventData.Add("amount", charge.Amount);
+        result.EventData.Add("currency", charge.Currency);
+        result.EventData.Add("payment_method", charge.PaymentMethod ?? string.Empty);
+
+        // Add charge outcome information (risk assessment, etc.)
+        if (charge.Outcome != null)
+        {
+            result.EventData.Add("risk_level", charge.Outcome.RiskLevel ?? "unknown");
+            result.EventData.Add("outcome_type", charge.Outcome.Type ?? "unknown");
+            result.EventData.Add("seller_message", charge.Outcome.SellerMessage ?? string.Empty);
+
+            if (!string.IsNullOrEmpty(charge.Outcome.Reason))
+            {
+                result.EventData.Add("outcome_reason", charge.Outcome.Reason);
+            }
+        }
+
+        // Add payment method details if available
+        if (charge.PaymentMethodDetails?.Card != null)
+        {
+            var card = charge.PaymentMethodDetails.Card;
+            result.EventData.Add("card_brand", card.Brand ?? string.Empty);
+            result.EventData.Add("card_last4", card.Last4 ?? string.Empty);
+            result.EventData.Add("card_country", card.Country ?? string.Empty);
+
+            if (card.ThreeDSecure != null)
+            {
+                result.EventData.Add("three_d_secure_result", card.ThreeDSecure.Result ?? string.Empty);
+                result.EventData.Add("three_d_secure_version", card.ThreeDSecure.Version ?? string.Empty);
+            }
+        }
+
+        // Add charge metadata
+        if (charge.Metadata != null && charge.Metadata.Count > 0)
+        {
+            result.EventData.Add("metadata", charge.Metadata);
+        }
+
+        // Add billing details if available
+        if (charge.BillingDetails != null)
+        {
+            result.EventData.Add("billing_email", charge.BillingDetails.Email ?? string.Empty);
+            result.EventData.Add("billing_name", charge.BillingDetails.Name ?? string.Empty);
+        }
+
+        result.OrderId = charge.Metadata["orderId"];
+        result.ProcessingMessage = "Charge succeeded";
+        result.IsProcessed = true;
+
+        _logger.LogInformation(
+            "Charge succeeded: {ChargeId} for PaymentIntent: {PaymentIntentId}, Amount: {Amount} {Currency}",
+            charge.Id, charge.PaymentIntentId, charge.Amount, charge.Currency?.ToUpperInvariant());
+
+        // Log 3DS information if available
+        if (charge.PaymentMethodDetails?.Card?.ThreeDSecure != null)
+        {
+            var threeDSecure = charge.PaymentMethodDetails.Card.ThreeDSecure;
+            _logger.LogInformation(
+                "3D Secure authentication completed for charge {ChargeId}: Result={Result}, Version={Version}",
+                charge.Id, threeDSecure.Result, threeDSecure.Version);
+        }
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/CustomerCreatedHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/CustomerCreatedHandler.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class CustomerCreatedHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<CustomerCreatedHandler> _logger;
+
+    public CustomerCreatedHandler(ILogger<CustomerCreatedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var customer = stripeEvent.Data.Object as Customer;
+        if (customer == null)
+        {
+            result.ProcessingMessage = "Invalid Customer data in webhook";
+            return result;
+        }
+
+        result.CustomerId = customer.Id;
+        result.EventData.Add("email", customer.Email ?? string.Empty);
+
+        if (customer.Metadata != null)
+        {
+            result.EventData.Add("metadata", customer.Metadata);
+        }
+
+        result.ProcessingMessage = $"Customer created: {customer.Id}";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Customer created: {CustomerId}", customer.Id);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/CustomerUpdatedHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/CustomerUpdatedHandler.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class CustomerUpdatedHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<CustomerUpdatedHandler> _logger;
+
+    public CustomerUpdatedHandler(ILogger<CustomerUpdatedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var customer = stripeEvent.Data.Object as Customer;
+        if (customer == null)
+        {
+            result.ProcessingMessage = "Invalid Customer data in webhook";
+            return result;
+        }
+
+        result.CustomerId = customer.Id;
+        result.EventData.Add("email", customer.Email ?? string.Empty);
+
+        if (customer.Metadata != null)
+        {
+            result.EventData.Add("metadata", customer.Metadata);
+        }
+
+        result.ProcessingMessage = $"Customer updated: {customer.Id}";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Customer updated: {CustomerId}", customer.Id);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/IStripeWebhookHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/IStripeWebhookHandler.cs
@@ -1,0 +1,9 @@
+using Shopilent.Application.Abstractions.Payments;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal interface IStripeWebhookHandler
+{
+    Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken);
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentCanceledHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentCanceledHandler.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class PaymentIntentCanceledHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<PaymentIntentCanceledHandler> _logger;
+
+    public PaymentIntentCanceledHandler(ILogger<PaymentIntentCanceledHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var paymentIntent = stripeEvent.Data.Object as PaymentIntent;
+        if (paymentIntent == null)
+        {
+            result.ProcessingMessage = "Invalid PaymentIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = paymentIntent.Id;
+        result.PaymentStatus = PaymentStatus.Canceled;
+        result.CustomerId = paymentIntent.CustomerId;
+
+        if (paymentIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", paymentIntent.Metadata);
+        }
+
+        result.OrderId = paymentIntent.Metadata["orderId"];
+        result.ProcessingMessage = "Payment was canceled";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Payment canceled: {PaymentIntentId}", paymentIntent.Id);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentFailedHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentFailedHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class PaymentIntentFailedHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<PaymentIntentFailedHandler> _logger;
+
+    public PaymentIntentFailedHandler(ILogger<PaymentIntentFailedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var paymentIntent = stripeEvent.Data.Object as PaymentIntent;
+        if (paymentIntent == null)
+        {
+            result.ProcessingMessage = "Invalid PaymentIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = paymentIntent.Id;
+        result.PaymentStatus = PaymentStatus.Failed;
+        result.CustomerId = paymentIntent.CustomerId;
+        result.EventData.Add("last_payment_error", paymentIntent.LastPaymentError?.Message ?? "Unknown error");
+
+        if (paymentIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", paymentIntent.Metadata);
+        }
+
+        result.OrderId = paymentIntent.Metadata["orderId"];
+        result.ProcessingMessage = $"Payment failed: {paymentIntent.LastPaymentError?.Message ?? "Unknown error"}";
+        result.IsProcessed = true;
+
+        _logger.LogWarning("Payment failed: {PaymentIntentId}, Error: {Error}",
+            paymentIntent.Id, paymentIntent.LastPaymentError?.Message);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentRequiresActionHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentRequiresActionHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class PaymentIntentRequiresActionHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<PaymentIntentRequiresActionHandler> _logger;
+
+    public PaymentIntentRequiresActionHandler(ILogger<PaymentIntentRequiresActionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var paymentIntent = stripeEvent.Data.Object as PaymentIntent;
+        if (paymentIntent == null)
+        {
+            result.ProcessingMessage = "Invalid PaymentIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = paymentIntent.Id;
+        result.PaymentStatus = PaymentStatus.RequiresAction;
+        result.CustomerId = paymentIntent.CustomerId;
+        result.EventData.Add("next_action", paymentIntent.NextAction?.Type ?? "unknown");
+
+        if (paymentIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", paymentIntent.Metadata);
+        }
+
+        result.OrderId = paymentIntent.Metadata["orderId"];
+        result.ProcessingMessage = "Payment requires additional action";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Payment requires action: {PaymentIntentId}", paymentIntent.Id);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentSucceededHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentIntentSucceededHandler.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class PaymentIntentSucceededHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<PaymentIntentSucceededHandler> _logger;
+
+    public PaymentIntentSucceededHandler(ILogger<PaymentIntentSucceededHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var paymentIntent = stripeEvent.Data.Object as PaymentIntent;
+        if (paymentIntent == null)
+        {
+            result.ProcessingMessage = "Invalid PaymentIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = paymentIntent.Id;
+        result.PaymentStatus = PaymentStatus.Succeeded;
+        result.CustomerId = paymentIntent.CustomerId;
+        result.EventData.Add("amount", paymentIntent.Amount);
+        result.EventData.Add("currency", paymentIntent.Currency);
+        result.EventData.Add("payment_method", paymentIntent.PaymentMethodId);
+
+        if (paymentIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", paymentIntent.Metadata);
+        }
+
+        result.OrderId = paymentIntent.Metadata["orderId"];
+        result.ProcessingMessage = "Payment succeeded";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Payment succeeded: {PaymentIntentId}", paymentIntent.Id);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentMethodAttachedHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/PaymentMethodAttachedHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class PaymentMethodAttachedHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<PaymentMethodAttachedHandler> _logger;
+
+    public PaymentMethodAttachedHandler(ILogger<PaymentMethodAttachedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var paymentMethod = stripeEvent.Data.Object as PaymentMethod;
+        if (paymentMethod == null)
+        {
+            result.ProcessingMessage = "Invalid PaymentMethod data in webhook";
+            return result;
+        }
+
+        result.CustomerId = paymentMethod.CustomerId;
+        result.EventData.Add("payment_method_id", paymentMethod.Id);
+        result.EventData.Add("payment_method_type", paymentMethod.Type);
+
+        if (paymentMethod.Card != null)
+        {
+            result.EventData.Add("card_brand", paymentMethod.Card.Brand);
+            result.EventData.Add("card_last4", paymentMethod.Card.Last4);
+            result.EventData.Add("card_exp_month", paymentMethod.Card.ExpMonth);
+            result.EventData.Add("card_exp_year", paymentMethod.Card.ExpYear);
+        }
+
+        result.ProcessingMessage = $"Payment method attached: {paymentMethod.Id}";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Payment method attached: {PaymentMethodId} to customer: {CustomerId}",
+            paymentMethod.Id, paymentMethod.CustomerId);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/StripeWebhookHandlerFactory.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/StripeWebhookHandlerFactory.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class StripeWebhookHandlerFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<StripeWebhookHandlerFactory> _logger;
+
+    public StripeWebhookHandlerFactory(IServiceProvider serviceProvider, ILogger<StripeWebhookHandlerFactory> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    public IStripeWebhookHandler? GetHandler(string eventType)
+    {
+        return eventType switch
+        {
+            "payment_intent.succeeded" => _serviceProvider.GetRequiredService<PaymentIntentSucceededHandler>(),
+            "payment_intent.payment_failed" => _serviceProvider.GetRequiredService<PaymentIntentFailedHandler>(),
+            "payment_intent.requires_action" => _serviceProvider.GetRequiredService<PaymentIntentRequiresActionHandler>(),
+            "payment_intent.canceled" => _serviceProvider.GetRequiredService<PaymentIntentCanceledHandler>(),
+            "charge.succeeded" => _serviceProvider.GetRequiredService<ChargeSucceededHandler>(),
+            "charge.dispute.created" => _serviceProvider.GetRequiredService<ChargeDisputeCreatedHandler>(),
+            "customer.created" => _serviceProvider.GetRequiredService<CustomerCreatedHandler>(),
+            "customer.updated" => _serviceProvider.GetRequiredService<CustomerUpdatedHandler>(),
+            "payment_method.attached" => _serviceProvider.GetRequiredService<PaymentMethodAttachedHandler>(),
+            _ => null
+        };
+    }
+}


### PR DESCRIPTION
- Added individual event handlers implementing `IStripeWebhookHandler` for various Stripe webhook events (e.g., `PaymentIntentSucceeded`, `ChargeDisputeCreated`, `CustomerCreated`).
- Introduced `StripeWebhookHandlerFactory` for resolving appropriate handlers based on event type.
- Updated `StripePaymentProvider` to delegate event handling to `StripeWebhookHandlerFactory`.
- Removed inline event handling logic from `StripePaymentProvider` for cleaner separation of concerns.