### PR TITLE
Add support for Stripe Setup Intents

### DIFF
--- a/Shopilent.API/Endpoints/Payments/AddPaymentMethod/V1/AddPaymentMethodRequestV1.cs
+++ b/Shopilent.API/Endpoints/Payments/AddPaymentMethod/V1/AddPaymentMethodRequestV1.cs
@@ -4,7 +4,6 @@ public class AddPaymentMethodRequestV1
 {
     public string Type { get; init; } // "CreditCard", "PayPal"
     public string Provider { get; init; } // "Stripe", "PayPal", "Braintree"
-    public string Token { get; init; }
     public string DisplayName { get; init; }
     public bool IsDefault { get; init; } = false;
     
@@ -18,4 +17,11 @@ public class AddPaymentMethodRequestV1
     
     // Additional metadata
     public Dictionary<string, object> Metadata { get; init; } = new();
+    
+    // Payment Method Token
+    public string? PaymentMethodToken { get; init; }
+    
+    // 3DS Setup Intent Support
+    public bool RequiresSetupIntent { get; init; } = false;
+    public string? SetupIntentId { get; init; }
 }

--- a/Shopilent.API/Endpoints/Payments/AddPaymentMethod/V1/AddPaymentMethodRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Payments/AddPaymentMethod/V1/AddPaymentMethodRequestValidatorV1.cs
@@ -16,9 +16,6 @@ public class AddPaymentMethodRequestValidatorV1 : Validator<AddPaymentMethodRequ
             .NotEmpty().WithMessage("Payment provider is required.")
             .Must(BeValidPaymentProvider).WithMessage("Invalid payment provider. Valid providers: Stripe, PayPal, Braintree.");
 
-        RuleFor(x => x.Token)
-            .NotEmpty().WithMessage("Payment method token is required.")
-            .MaximumLength(255).WithMessage("Token cannot exceed 255 characters.");
 
         RuleFor(x => x.DisplayName)
             .NotEmpty().WithMessage("Display name is required.")

--- a/Shopilent.Application/Abstractions/Payments/IPaymentService.cs
+++ b/Shopilent.Application/Abstractions/Payments/IPaymentService.cs
@@ -46,4 +46,19 @@ public interface IPaymentService
         string signature = null,
         Dictionary<string, string> headers = null,
         CancellationToken cancellationToken = default);
+
+    // Setup intent methods
+    Task<Result<SetupIntentResult>> CreateSetupIntentAsync(
+        PaymentProvider provider,
+        string customerId,
+        string paymentMethodToken = null,
+        Dictionary<string, object> metadata = null,
+        string usage = "off_session",
+        CancellationToken cancellationToken = default);
+
+    Task<Result<SetupIntentResult>> ConfirmSetupIntentAsync(
+        PaymentProvider provider,
+        string setupIntentId,
+        string paymentMethodToken = null,
+        CancellationToken cancellationToken = default);
 }

--- a/Shopilent.Application/Abstractions/Payments/SetupIntentResult.cs
+++ b/Shopilent.Application/Abstractions/Payments/SetupIntentResult.cs
@@ -1,0 +1,16 @@
+using Shopilent.Domain.Payments.Enums;
+
+namespace Shopilent.Application.Abstractions.Payments;
+
+public class SetupIntentResult
+{
+    public string SetupIntentId { get; set; }
+    public PaymentStatus Status { get; set; }
+    public string ClientSecret { get; set; }
+    public bool RequiresAction { get; set; }
+    public string NextActionType { get; set; }
+    public string PaymentMethodId { get; set; }
+    public string CustomerId { get; set; }
+    public Dictionary<string, object> Metadata { get; set; } = new();
+    public string Usage { get; set; }
+}

--- a/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodCommandV1.cs
+++ b/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodCommandV1.cs
@@ -6,7 +6,6 @@ public sealed record AddPaymentMethodCommandV1 : ICommand<AddPaymentMethodRespon
 {
     public string Type { get; init; } // "CreditCard", "PayPal"
     public string Provider { get; init; } // "Stripe", "PayPal", "Braintree"
-    public string Token { get; init; }
     public string DisplayName { get; init; }
     public bool IsDefault { get; init; } = false;
     
@@ -20,4 +19,11 @@ public sealed record AddPaymentMethodCommandV1 : ICommand<AddPaymentMethodRespon
     
     // Additional metadata
     public Dictionary<string, object> Metadata { get; init; } = new();
+    
+    // Payment Method Token
+    public string? PaymentMethodToken { get; init; }
+    
+    // 3DS Setup Intent Support
+    public bool RequiresSetupIntent { get; init; } = false;
+    public string? SetupIntentId { get; init; }
 }

--- a/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodResponseV1.cs
+++ b/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodResponseV1.cs
@@ -13,4 +13,9 @@ public sealed class AddPaymentMethodResponseV1
     public bool IsActive { get; init; }
     public Dictionary<string, object> Metadata { get; init; }
     public DateTime CreatedAt { get; init; }
+    public bool RequiresAuthentication { get; init; } = false;
+    public string? SetupIntentId { get; init; }
+    public string? ClientSecret { get; init; }
+    public string? NextActionType { get; init; }
+    public string? PaymentMethodToken { get; init; }
 }

--- a/Shopilent.Infrastructure.Payments/Abstractions/IPaymentProvider.cs
+++ b/Shopilent.Infrastructure.Payments/Abstractions/IPaymentProvider.cs
@@ -60,4 +60,29 @@ public interface IPaymentProvider
                 code: "Webhook.NotSupported",
                 message: $"Webhook processing is not supported by {Provider} provider")));
     }
+    
+    // Setup intent methods - optional for providers that support it
+    Task<Result<SetupIntentResult>> CreateSetupIntentAsync(
+        string customerId,
+        string paymentMethodToken = null,
+        Dictionary<string, object> metadata = null,
+        string usage = "off_session",
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Result.Failure<SetupIntentResult>(
+            Domain.Common.Errors.Error.Failure(
+                code: "SetupIntent.NotSupported",
+                message: $"Setup intent is not supported by {Provider} provider")));
+    }
+    
+    Task<Result<SetupIntentResult>> ConfirmSetupIntentAsync(
+        string setupIntentId,
+        string paymentMethodToken = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Result.Failure<SetupIntentResult>(
+            Domain.Common.Errors.Error.Failure(
+                code: "SetupIntent.NotSupported",
+                message: $"Setup intent confirmation is not supported by {Provider} provider")));
+    }
 }

--- a/Shopilent.Infrastructure.Payments/Extensions/PaymentsServiceExtensions.cs
+++ b/Shopilent.Infrastructure.Payments/Extensions/PaymentsServiceExtensions.cs
@@ -34,6 +34,9 @@ public static class PaymentsServiceExtensions
         services.AddScoped<CustomerCreatedHandler>();
         services.AddScoped<CustomerUpdatedHandler>();
         services.AddScoped<PaymentMethodAttachedHandler>();
+        services.AddScoped<SetupIntentSucceededHandler>();
+        services.AddScoped<SetupIntentRequiresActionHandler>();
+        services.AddScoped<SetupIntentCanceledHandler>();
         services.AddScoped<StripeWebhookHandlerFactory>();
 
         return services;

--- a/Shopilent.Infrastructure.Payments/Models/PaymentRequest.cs
+++ b/Shopilent.Infrastructure.Payments/Models/PaymentRequest.cs
@@ -10,4 +10,5 @@ public class PaymentRequest
     public string PaymentMethodToken { get; init; }
     public string CustomerId { get; init; }
     public Dictionary<string, object> Metadata { get; init; } = new();
+    public bool SavePaymentMethod { get; init; }
 }

--- a/Shopilent.Infrastructure.Payments/Providers/Base/PaymentProviderBase.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Base/PaymentProviderBase.cs
@@ -68,6 +68,29 @@ public abstract class PaymentProviderBase : IPaymentProvider
                 message: $"Webhook processing is not supported by {Provider} provider")));
     }
 
+    public virtual Task<Result<SetupIntentResult>> CreateSetupIntentAsync(
+        string customerId,
+        string paymentMethodToken = null,
+        Dictionary<string, object> metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Result.Failure<SetupIntentResult>(
+            Domain.Common.Errors.Error.Failure(
+                code: "SetupIntent.NotSupported",
+                message: $"Setup intent is not supported by {Provider} provider")));
+    }
+
+    public virtual Task<Result<SetupIntentResult>> ConfirmSetupIntentAsync(
+        string setupIntentId,
+        string paymentMethodToken = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Result.Failure<SetupIntentResult>(
+            Domain.Common.Errors.Error.Failure(
+                code: "SetupIntent.NotSupported",
+                message: $"Setup intent confirmation is not supported by {Provider} provider")));
+    }
+
     protected virtual void LogPaymentOperation(string operation, string transactionId, PaymentStatus? status = null)
     {
         Logger.LogInformation("Payment operation {Operation} for transaction {TransactionId} with status {Status}",

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentCanceledHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentCanceledHandler.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class SetupIntentCanceledHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<SetupIntentCanceledHandler> _logger;
+
+    public SetupIntentCanceledHandler(ILogger<SetupIntentCanceledHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var setupIntent = stripeEvent.Data.Object as SetupIntent;
+        if (setupIntent == null)
+        {
+            result.ProcessingMessage = "Invalid SetupIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = setupIntent.Id;
+        result.PaymentStatus = PaymentStatus.Canceled;
+        result.CustomerId = setupIntent.CustomerId;
+        result.EventData.Add("payment_method_id", setupIntent.PaymentMethodId ?? string.Empty);
+        result.EventData.Add("usage", setupIntent.Usage ?? string.Empty);
+
+        // Add cancellation reason if available
+        if (setupIntent.CancellationReason != null)
+        {
+            result.EventData.Add("cancellation_reason", setupIntent.CancellationReason);
+        }
+
+        if (setupIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", setupIntent.Metadata);
+        }
+
+        result.OrderId = setupIntent.Metadata?.GetValueOrDefault("orderId");
+        result.ProcessingMessage = $"Setup intent canceled: {setupIntent.CancellationReason ?? "Unknown reason"}";
+        result.IsProcessed = true;
+
+        _logger.LogWarning("Setup intent canceled: {SetupIntentId} for customer {CustomerId}, reason: {CancellationReason}",
+            setupIntent.Id, setupIntent.CustomerId, setupIntent.CancellationReason);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentRequiresActionHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentRequiresActionHandler.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class SetupIntentRequiresActionHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<SetupIntentRequiresActionHandler> _logger;
+
+    public SetupIntentRequiresActionHandler(ILogger<SetupIntentRequiresActionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var setupIntent = stripeEvent.Data.Object as SetupIntent;
+        if (setupIntent == null)
+        {
+            result.ProcessingMessage = "Invalid SetupIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = setupIntent.Id;
+        result.PaymentStatus = PaymentStatus.RequiresAction;
+        result.CustomerId = setupIntent.CustomerId;
+        result.EventData.Add("payment_method_id", setupIntent.PaymentMethodId ?? string.Empty);
+        result.EventData.Add("usage", setupIntent.Usage ?? string.Empty);
+
+        // Add next action information
+        if (setupIntent.NextAction != null)
+        {
+            result.EventData.Add("next_action_type", setupIntent.NextAction.Type);
+            result.EventData.Add("client_secret", setupIntent.ClientSecret ?? string.Empty);
+        }
+
+        if (setupIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", setupIntent.Metadata);
+        }
+
+        result.OrderId = setupIntent.Metadata?.GetValueOrDefault("orderId");
+        result.ProcessingMessage = "Setup intent requires action - 3D Secure authentication needed";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Setup intent requires action: {SetupIntentId} for customer {CustomerId}, action type: {NextActionType}",
+            setupIntent.Id, setupIntent.CustomerId, setupIntent.NextAction?.Type);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentSucceededHandler.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/SetupIntentSucceededHandler.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Payments;
+using Shopilent.Domain.Payments.Enums;
+using Stripe;
+
+namespace Shopilent.Infrastructure.Payments.Providers.Stripe.Handlers;
+
+internal class SetupIntentSucceededHandler : IStripeWebhookHandler
+{
+    private readonly ILogger<SetupIntentSucceededHandler> _logger;
+
+    public SetupIntentSucceededHandler(ILogger<SetupIntentSucceededHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<WebhookResult> HandleAsync(Event stripeEvent, WebhookResult result, CancellationToken cancellationToken)
+    {
+        var setupIntent = stripeEvent.Data.Object as SetupIntent;
+        if (setupIntent == null)
+        {
+            result.ProcessingMessage = "Invalid SetupIntent data in webhook";
+            return result;
+        }
+
+        result.TransactionId = setupIntent.Id;
+        result.PaymentStatus = PaymentStatus.Succeeded;
+        result.CustomerId = setupIntent.CustomerId;
+        result.EventData.Add("payment_method_id", setupIntent.PaymentMethodId ?? string.Empty);
+        result.EventData.Add("usage", setupIntent.Usage ?? string.Empty);
+
+        if (setupIntent.Metadata != null)
+        {
+            result.EventData.Add("metadata", setupIntent.Metadata);
+        }
+
+        // For setup intents, we don't have an order ID, but we can store the customer ID
+        result.OrderId = setupIntent.Metadata?.GetValueOrDefault("orderId");
+        result.ProcessingMessage = "Setup intent succeeded - payment method set up for future use";
+        result.IsProcessed = true;
+
+        _logger.LogInformation("Setup intent succeeded: {SetupIntentId} for customer {CustomerId}, payment method: {PaymentMethodId}",
+            setupIntent.Id, setupIntent.CustomerId, setupIntent.PaymentMethodId);
+
+        return result;
+    }
+}

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/StripeWebhookHandlerFactory.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/Handlers/StripeWebhookHandlerFactory.cs
@@ -27,6 +27,9 @@ internal class StripeWebhookHandlerFactory
             "customer.created" => _serviceProvider.GetRequiredService<CustomerCreatedHandler>(),
             "customer.updated" => _serviceProvider.GetRequiredService<CustomerUpdatedHandler>(),
             "payment_method.attached" => _serviceProvider.GetRequiredService<PaymentMethodAttachedHandler>(),
+            "setup_intent.succeeded" => _serviceProvider.GetRequiredService<SetupIntentSucceededHandler>(),
+            "setup_intent.requires_action" => _serviceProvider.GetRequiredService<SetupIntentRequiresActionHandler>(),
+            "setup_intent.canceled" => _serviceProvider.GetRequiredService<SetupIntentCanceledHandler>(),
             _ => null
         };
     }


### PR DESCRIPTION
- Added `SetupIntentResult` model to handle setup intent results.
- Introduced `SetupIntentSucceededHandler`, `SetupIntentRequiresActionHandler`, and `SetupIntentCanceledHandler` for setup intent webhook events.
- Enhanced `StripePaymentProvider` with methods to create and confirm setup intents.
- Updated `PaymentService` and `IPaymentProvider` interface to include setup intent-related methods.
- Extended `AddPaymentMethodEndpointV1` to support 3D Secure (3DS) authentication flow via setup intents.
- Registered setup intent handlers in `PaymentsServiceExtensions`.
- Updated `StripeWebhookHandlerFactory` to route setup intent webhook events to appropriate handlers.
- Refactored validation and request models to include setup intent-related fields.