### PR TITLE
Remove unused `usage` parameter from setup intent methods

### DIFF
--- a/Shopilent.Application/Abstractions/Payments/IPaymentService.cs
+++ b/Shopilent.Application/Abstractions/Payments/IPaymentService.cs
@@ -53,7 +53,6 @@ public interface IPaymentService
         string customerId,
         string paymentMethodToken = null,
         Dictionary<string, object> metadata = null,
-        string usage = "off_session",
         CancellationToken cancellationToken = default);
 
     Task<Result<SetupIntentResult>> ConfirmSetupIntentAsync(

--- a/Shopilent.Infrastructure.Payments/Abstractions/IPaymentProvider.cs
+++ b/Shopilent.Infrastructure.Payments/Abstractions/IPaymentProvider.cs
@@ -66,7 +66,6 @@ public interface IPaymentProvider
         string customerId,
         string paymentMethodToken = null,
         Dictionary<string, object> metadata = null,
-        string usage = "off_session",
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult(Result.Failure<SetupIntentResult>(

--- a/Shopilent.Infrastructure.Payments/Services/PaymentService.cs
+++ b/Shopilent.Infrastructure.Payments/Services/PaymentService.cs
@@ -211,7 +211,6 @@ internal class PaymentService : IPaymentService
         string customerId,
         string paymentMethodToken = null,
         Dictionary<string, object> metadata = null,
-        string usage = "off_session",
         CancellationToken cancellationToken = default)
     {
         try
@@ -223,7 +222,7 @@ internal class PaymentService : IPaymentService
                     Domain.Payments.Errors.PaymentErrors.InvalidProvider);
             }
 
-            return await paymentProvider.CreateSetupIntentAsync(customerId, paymentMethodToken, metadata, usage, cancellationToken);
+            return await paymentProvider.CreateSetupIntentAsync(customerId, paymentMethodToken, metadata, cancellationToken);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
- Eliminated the `usage` parameter from `CreateSetupIntentAsync` and related method signatures in `PaymentService`, `IPaymentProvider`, and `IPaymentService`.
- Updated implementations and call sites for compatibility.