### PR TITLE
Refactor PostgreSQL configurations

### DIFF
--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Context/ApplicationDbContext.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Context/ApplicationDbContext.cs
@@ -8,13 +8,10 @@ using Shopilent.Domain.Shipping;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Shopilent.Application.Abstractions.Events;
-using Shopilent.Application.Abstractions.Outbox;
 using Shopilent.Domain.Common;
 using Shopilent.Domain.Common.Events;
 using Shopilent.Domain.Outbox;
-using Shopilent.Infrastructure.Persistence.PostgreSQL.Extensions;
 using Attribute = Shopilent.Domain.Catalog.Attribute;
-using System.Reflection;
 
 namespace Shopilent.Infrastructure.Persistence.PostgreSQL.Context;
 
@@ -118,5 +115,21 @@ public class ApplicationDbContext : DbContext
 
     private void UpdateTimestamps()
     {
+        var entries = ChangeTracker.Entries()
+            .Where(e => e.Entity is Domain.Common.Entity && (
+                e.State == EntityState.Added || 
+                e.State == EntityState.Modified));
+                
+        foreach (var entry in entries)
+        {
+            var now = DateTime.UtcNow;
+            
+            if (entry.State == EntityState.Added)
+            {
+                entry.Property(nameof(Domain.Common.Entity.CreatedAt)).CurrentValue = now;
+            }
+            
+            entry.Property(nameof(Domain.Common.Entity.UpdatedAt)).CurrentValue = now;
+        }
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
@@ -107,6 +107,8 @@ public class AuditSaveChangesInterceptor : SaveChangesInterceptor
                     break;
 
                 case EntityState.Modified:
+                    entry.Entity.IncrementVersion();
+                   
                     var oldValues = GetOriginalValues(entry);
                     var currentValues = GetEntityValues(entry);
                     CreateAuditLog(context, entityType, entry.Entity.Id, AuditAction.Update, user,

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Audit/AuditLogConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Audit/AuditLogConfiguration.cs
@@ -87,7 +87,7 @@ public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
         builder.Property(al => al.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
         
         // Relationships
         builder.HasOne<Domain.Identity.User>()

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/AttributeConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/AttributeConfiguration.cs
@@ -106,6 +106,6 @@ public class AttributeConfiguration : IEntityTypeConfiguration<Attribute>
         builder.Property(a => a.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/CategoryConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/CategoryConfiguration.cs
@@ -101,6 +101,6 @@ public class CategoryConfiguration : IEntityTypeConfiguration<Category>
         builder.Property(c => c.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductAttributeConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductAttributeConfiguration.cs
@@ -61,7 +61,7 @@ public class ProductAttributeConfiguration : IEntityTypeConfiguration<ProductAtt
         builder.Property(pa => pa.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
 
         // Relationships
         builder.HasOne<Product>()

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductCategoryConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductCategoryConfiguration.cs
@@ -52,7 +52,7 @@ public class ProductCategoryConfiguration : IEntityTypeConfiguration<ProductCate
         builder.Property(c => c.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
         
         // Indexes
         builder.HasIndex(pc => pc.ProductId);

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductConfiguration.cs
@@ -141,7 +141,7 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
         builder.Property(p => p.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
 
 
         builder.OwnsMany(p => p.Images, images =>

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductVariantConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/ProductVariantConfiguration.cs
@@ -98,7 +98,7 @@ public class ProductVariantConfiguration : IEntityTypeConfiguration<ProductVaria
         builder.Property(pv => pv.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
 
         // Relationships
         builder.HasOne<Product>()
@@ -128,7 +128,7 @@ public class ProductVariantConfiguration : IEntityTypeConfiguration<ProductVaria
         builder.Property(pv => pv.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
 
         builder.OwnsMany(v => v.Images, images =>
         {

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/VariantAttributeConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Catalog/VariantAttributeConfiguration.cs
@@ -60,7 +60,7 @@ public class VariantAttributeConfiguration : IEntityTypeConfiguration<VariantAtt
         builder.Property(va => va.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
         
         // Relationships
         builder.HasOne<ProductVariant>()

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Identity/RefreshTokenConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Identity/RefreshTokenConfiguration.cs
@@ -89,6 +89,6 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
         builder.Property(rt => rt.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Identity/UserConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Identity/UserConfiguration.cs
@@ -161,7 +161,7 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
 
         // Check constraint for email format
         builder.HasCheckConstraint("check_email_format",

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Payments/PaymentConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Payments/PaymentConfiguration.cs
@@ -160,6 +160,6 @@ public class PaymentConfiguration : IEntityTypeConfiguration<Payment>
         builder.Property(p => p.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Payments/PaymentMethodConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Payments/PaymentMethodConfiguration.cs
@@ -125,6 +125,6 @@ public class PaymentMethodConfiguration : IEntityTypeConfiguration<PaymentMethod
         builder.Property(pm => pm.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/CartConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/CartConfiguration.cs
@@ -75,6 +75,6 @@ public class CartConfiguration : IEntityTypeConfiguration<Cart>
         builder.Property(c => c.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/CartItemConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/CartItemConfiguration.cs
@@ -77,6 +77,6 @@ public class CartItemConfiguration : IEntityTypeConfiguration<CartItem>
         builder.Property(ci => ci.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/OrderConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/OrderConfiguration.cs
@@ -213,6 +213,6 @@ public class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.Property(o => o.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/OrderItemConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Sales/OrderItemConfiguration.cs
@@ -118,6 +118,6 @@ public class OrderItemConfiguration : IEntityTypeConfiguration<OrderItem>
         builder.Property(oi => oi.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Shipping/AddressConfiguration.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Mappings/Shipping/AddressConfiguration.cs
@@ -117,6 +117,6 @@ public class AddressConfiguration : IEntityTypeConfiguration<Address>
         builder.Property(a => a.Version)
             .HasColumnName("version")
             .HasDefaultValue(0)
-            .IsRowVersion();
+            .IsConcurrencyToken();
     }
 }


### PR DESCRIPTION
- Replaced `.IsRowVersion()` with `.IsConcurrencyToken()` for entity version properties.
- Updated `UpdateTimestamps` method in `ApplicationDbContext` to streamline timestamp management for `CreatedAt` and `UpdatedAt`.
- Incremented entity version in `AuditSaveChangesInterceptor` during modification tracking.
- Removed redundant `using` directives for cleaner code organization.