### PR TITLE
Add role-based order cancellation logic

### DIFF
--- a/Shopilent.Application/Features/Sales/Commands/CancelOrder/V1/CancelOrderCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/CancelOrder/V1/CancelOrderCommandHandlerV1.cs
@@ -46,8 +46,9 @@ internal sealed class CancelOrderCommandHandlerV1 : ICommandHandler<CancelOrderC
                     Error.Forbidden("Order.CancelDenied", "You are not authorized to cancel this order"));
             }
 
-            // Attempt to cancel the order using domain logic
-            var cancelResult = order.Cancel(request.Reason);
+            // Attempt to cancel the order using domain logic with role-based permissions
+            var isAdminOrManager = request.IsAdmin || request.IsManager;
+            var cancelResult = order.Cancel(request.Reason, isAdminOrManager);
             
             if (cancelResult.IsFailure)
             {


### PR DESCRIPTION
- Updated `Order.Cancel` method to enforce cancellation rules based on user roles (customers vs. admins/managers).
- Adjusted `CancelOrderCommandHandlerV1` to include role-based permission checks.
- Added unit tests to validate cancellation behavior for different order statuses and user roles.