### PR TITLE
Prefix flat attributes with `attr-` for consistency in search handling

### DIFF
--- a/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
+++ b/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
@@ -257,7 +257,7 @@ partial class ProductSearchDocument
                 
                 if (!string.IsNullOrEmpty(value))
                 {
-                    flatAttributes[attributeName] = new[] { value };
+                    flatAttributes[$"attr-{attributeName}"] = new[] { value };
                 }
             }
         }
@@ -284,17 +284,18 @@ partial class ProductSearchDocument
                         
                         if (!string.IsNullOrEmpty(value))
                         {
-                            if (!flatAttributes.ContainsKey(attributeName))
+                            var prefixedAttributeName = $"attr-{attributeName}";
+                            if (!flatAttributes.ContainsKey(prefixedAttributeName))
                             {
-                                flatAttributes[attributeName] = new[] { value };
+                                flatAttributes[prefixedAttributeName] = new[] { value };
                             }
                             else
                             {
-                                var existingValues = flatAttributes[attributeName].ToList();
+                                var existingValues = flatAttributes[prefixedAttributeName].ToList();
                                 if (!existingValues.Contains(value))
                                 {
                                     existingValues.Add(value);
-                                    flatAttributes[attributeName] = existingValues.ToArray();
+                                    flatAttributes[prefixedAttributeName] = existingValues.ToArray();
                                 }
                             }
                         }

--- a/Shopilent.Infrastructure.Search.Meilisearch/Services/MeilisearchService.cs
+++ b/Shopilent.Infrastructure.Search.Meilisearch/Services/MeilisearchService.cs
@@ -39,7 +39,8 @@ public class MeilisearchService : ISearchService
                 "sku",
                 "variant_skus",
                 "categories.name",
-                "attributes.value"
+                "attributes.value",
+                "attr-*"
             });
 
             var currentFilterableAttrs = await index.GetFilterableAttributesAsync();
@@ -355,7 +356,7 @@ public class MeilisearchService : ISearchService
             {
                 if (values.Length > 0)
                 {
-                    var flatAttributeName = attributeName.ToLowerInvariant();
+                    var flatAttributeName = $"attr-{attributeName.ToLowerInvariant()}";
                     var attributeFilter = string.Join(" OR ", values.Select(value => 
                         $"{flatAttributeName} = \"{value}\""));
                     filters.Add($"({attributeFilter})");


### PR DESCRIPTION
- Updated `ProductSearchDocument` to prefix flat attributes during processing.
- Modified Meilisearch indexing logic to include `attr-*` as filterable attributes.
- Adjusted attribute filtering to utilize prefixed attribute names.