### PR TITLE
Introduce `FilterEncodingService` for base64 filter encoding/decoding

### DIFF
--- a/Shopilent.API/Common/Models/ProductFilters.cs
+++ b/Shopilent.API/Common/Models/ProductFilters.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Shopilent.API.Common.Models;
+
+public class ProductFilters
+{
+    [JsonPropertyName("attributeFilters")]
+    public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
+
+    [JsonPropertyName("categoryIds")]
+    public Guid[] CategoryIds { get; init; } = [];
+
+    [JsonPropertyName("priceMin")]
+    public decimal? PriceMin { get; init; }
+
+    [JsonPropertyName("priceMax")]
+    public decimal? PriceMax { get; init; }
+
+    [JsonPropertyName("inStockOnly")]
+    public bool InStockOnly { get; init; } = false;
+
+    [JsonPropertyName("activeOnly")]
+    public bool ActiveOnly { get; init; } = true;
+
+    [JsonPropertyName("searchQuery")]
+    public string SearchQuery { get; init; } = "";
+
+    [JsonPropertyName("pageNumber")]
+    public int PageNumber { get; init; } = 1;
+
+    [JsonPropertyName("pageSize")]
+    public int PageSize { get; init; } = 20;
+
+    [JsonPropertyName("sortBy")]
+    public string SortBy { get; init; } = "name";
+
+    [JsonPropertyName("sortDescending")]
+    public bool SortDescending { get; init; } = false;
+
+    [JsonPropertyName("categoryId")]
+    public Guid? CategoryId { get; init; }
+
+    [JsonPropertyName("sortColumn")]
+    public string SortColumn { get; init; } = "Name";
+}

--- a/Shopilent.API/Common/Services/FilterEncodingService.cs
+++ b/Shopilent.API/Common/Services/FilterEncodingService.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using System.Text.Json;
+using Shopilent.API.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Common.Services;
+
+public class FilterEncodingService : IFilterEncodingService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public Result<ProductFilters> DecodeFilters(string base64EncodedFilters)
+    {
+        if (string.IsNullOrWhiteSpace(base64EncodedFilters))
+        {
+            return Result.Failure<ProductFilters>(
+                Error.Validation("FilterEncoding.InvalidBase64", "Base64 encoded filters string is required"));
+        }
+
+        try
+        {
+            var base64Bytes = Convert.FromBase64String(base64EncodedFilters);
+            var jsonString = Encoding.UTF8.GetString(base64Bytes);
+
+            var filters = JsonSerializer.Deserialize<ProductFilters>(jsonString, JsonOptions);
+            
+            if (filters == null)
+            {
+                return Result.Failure<ProductFilters>(
+                    Error.Validation("FilterEncoding.DeserializationFailed", "Failed to deserialize filters from JSON"));
+            }
+
+            return Result.Success(filters);
+        }
+        catch (FormatException)
+        {
+            return Result.Failure<ProductFilters>(
+                Error.Validation("FilterEncoding.InvalidBase64Format", "Invalid base64 format"));
+        }
+        catch (JsonException ex)
+        {
+            return Result.Failure<ProductFilters>(
+                Error.Validation("FilterEncoding.InvalidJson", $"Invalid JSON format: {ex.Message}"));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<ProductFilters>(
+                Error.Failure("FilterEncoding.UnexpectedError", $"An unexpected error occurred while decoding filters: {ex.Message}"));
+        }
+    }
+
+    public string EncodeFilters(ProductFilters filters)
+    {
+        ArgumentNullException.ThrowIfNull(filters);
+
+        try
+        {
+            var jsonString = JsonSerializer.Serialize(filters, JsonOptions);
+            
+            var jsonBytes = Encoding.UTF8.GetBytes(jsonString);
+            return Convert.ToBase64String(jsonBytes);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to encode filters: {ex.Message}", ex);
+        }
+    }
+}

--- a/Shopilent.API/Common/Services/IFilterEncodingService.cs
+++ b/Shopilent.API/Common/Services/IFilterEncodingService.cs
@@ -1,0 +1,10 @@
+using Shopilent.API.Common.Models;
+using Shopilent.Domain.Common.Results;
+
+namespace Shopilent.API.Common.Services;
+
+public interface IFilterEncodingService
+{
+    Result<ProductFilters> DecodeFilters(string base64EncodedFilters);
+    string EncodeFilters(ProductFilters filters);
+}

--- a/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestV1.cs
+++ b/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestV1.cs
@@ -2,17 +2,5 @@ namespace Shopilent.API.Endpoints.Catalog.Products.GetPaginatedProducts.V1;
 
 public class GetPaginatedProductsRequestV1
 {
-    public int PageNumber { get; init; } = 1;
-    public int PageSize { get; init; } = 10;
-    public string SortColumn { get; init; } = "Name";
-    public bool SortDescending { get; init; } = false;
-    public Guid? CategoryId { get; init; }
-    public bool IsActiveOnly { get; init; } = true;
-    
-    public string SearchQuery { get; init; } = "";
-    public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
-    public decimal? PriceMin { get; init; }
-    public decimal? PriceMax { get; init; }
-    public Guid[] CategoryIds { get; init; } = [];
-    public bool InStockOnly { get; init; } = false;
+    public string FiltersBase64 { get; init; } = "";
 }

--- a/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestValidatorV1.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using FluentValidation;
+using Shopilent.API.Common.Services;
 
 namespace Shopilent.API.Endpoints.Catalog.Products.GetPaginatedProducts.V1;
 
@@ -7,39 +8,35 @@ public class GetPaginatedProductsRequestValidatorV1 : Validator<GetPaginatedProd
 {
     public GetPaginatedProductsRequestValidatorV1()
     {
-        RuleFor(x => x.PageNumber)
-            .GreaterThan(0).WithMessage("Page number must be greater than 0.");
-
-        RuleFor(x => x.PageSize)
-            .GreaterThan(0).WithMessage("Page size must be greater than 0.")
-            .LessThanOrEqualTo(100).WithMessage("Page size must not exceed 100.");
-
-        RuleFor(x => x.SortColumn)
-            .NotEmpty().WithMessage("Sort column cannot be empty.")
-            .Must(BeValidSortColumn).WithMessage("Invalid sort column. Valid columns are: name, price, created, updated.");
-
-        RuleFor(x => x.SearchQuery)
-            .MaximumLength(500)
-            .WithMessage("Search query cannot exceed 500 characters");
-
-        RuleFor(x => x.PriceMin)
-            .GreaterThanOrEqualTo(0)
-            .When(x => x.PriceMin.HasValue)
-            .WithMessage("Minimum price must be greater than or equal to 0");
-
-        RuleFor(x => x.PriceMax)
-            .GreaterThanOrEqualTo(0)
-            .When(x => x.PriceMax.HasValue)
-            .WithMessage("Maximum price must be greater than or equal to 0");
-
-        RuleFor(x => x)
-            .Must(x => !x.PriceMin.HasValue || !x.PriceMax.HasValue || x.PriceMin <= x.PriceMax)
-            .WithMessage("Minimum price must be less than or equal to maximum price");
+        RuleFor(x => x.FiltersBase64)
+            .NotEmpty().WithMessage("FiltersBase64 is required.")
+            .Must(BeValidBase64String).WithMessage("FiltersBase64 must be a valid base64 encoded string.")
+            .Must(BeValidFilterJson).WithMessage("FiltersBase64 must contain valid filter JSON.");
     }
 
-    private bool BeValidSortColumn(string sortColumn)
+    private bool BeValidBase64String(string base64String)
     {
-        var validColumns = new[] { "name", "price", "created", "updated" };
-        return validColumns.Contains(sortColumn, StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(base64String))
+            return false;
+
+        try
+        {
+            Convert.FromBase64String(base64String);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool BeValidFilterJson(string base64String)
+    {
+        if (string.IsNullOrWhiteSpace(base64String))
+            return false;
+
+        var filterEncodingService = new FilterEncodingService();
+        var result = filterEncodingService.DecodeFilters(base64String);
+        return result.IsSuccess;
     }
 }

--- a/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestV1.cs
+++ b/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestV1.cs
@@ -2,15 +2,5 @@ namespace Shopilent.API.Endpoints.Search.UniversalSearch.V1;
 
 public class UniversalSearchRequestV1
 {
-    public string Query { get; init; } = "";
-    public Guid[] CategoryIds { get; init; } = [];
-    public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
-    public decimal? PriceMin { get; init; }
-    public decimal? PriceMax { get; init; }
-    public bool InStockOnly { get; init; } = false;
-    public bool ActiveOnly { get; init; } = true;
-    public int PageNumber { get; init; } = 1;
-    public int PageSize { get; init; } = 20;
-    public string SortBy { get; init; } = "relevance";
-    public bool SortDescending { get; init; } = false;
+    public string FiltersBase64 { get; init; } = "";
 }

--- a/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestValidatorV1.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using FluentValidation;
+using Shopilent.API.Common.Services;
 
 namespace Shopilent.API.Endpoints.Search.UniversalSearch.V1;
 
@@ -7,41 +8,35 @@ public class UniversalSearchRequestValidatorV1 : Validator<UniversalSearchReques
 {
     public UniversalSearchRequestValidatorV1()
     {
-        RuleFor(x => x.PageNumber)
-            .GreaterThan(0)
-            .WithMessage("Page number must be greater than 0");
-
-        RuleFor(x => x.PageSize)
-            .GreaterThan(0)
-            .LessThanOrEqualTo(100)
-            .WithMessage("Page size must be between 1 and 100");
-
-        RuleFor(x => x.Query)
-            .MaximumLength(500)
-            .WithMessage("Search query cannot exceed 500 characters");
-
-        RuleFor(x => x.SortBy)
-            .Must(BeValidSortField)
-            .WithMessage("Invalid sort field. Valid options: relevance, name, price, created, updated, stock");
-
-        RuleFor(x => x.PriceMin)
-            .GreaterThanOrEqualTo(0)
-            .When(x => x.PriceMin.HasValue)
-            .WithMessage("Minimum price must be greater than or equal to 0");
-
-        RuleFor(x => x.PriceMax)
-            .GreaterThanOrEqualTo(0)
-            .When(x => x.PriceMax.HasValue)
-            .WithMessage("Maximum price must be greater than or equal to 0");
-
-        RuleFor(x => x)
-            .Must(x => !x.PriceMin.HasValue || !x.PriceMax.HasValue || x.PriceMin <= x.PriceMax)
-            .WithMessage("Minimum price must be less than or equal to maximum price");
+        RuleFor(x => x.FiltersBase64)
+            .NotEmpty().WithMessage("FiltersBase64 is required.")
+            .Must(BeValidBase64String).WithMessage("FiltersBase64 must be a valid base64 encoded string.")
+            .Must(BeValidFilterJson).WithMessage("FiltersBase64 must contain valid filter JSON.");
     }
 
-    private static bool BeValidSortField(string sortBy)
+    private bool BeValidBase64String(string base64String)
     {
-        var validFields = new[] { "relevance", "name", "price", "created", "updated", "stock" };
-        return validFields.Contains(sortBy.ToLowerInvariant());
+        if (string.IsNullOrWhiteSpace(base64String))
+            return false;
+
+        try
+        {
+            Convert.FromBase64String(base64String);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool BeValidFilterJson(string base64String)
+    {
+        if (string.IsNullOrWhiteSpace(base64String))
+            return false;
+
+        var filterEncodingService = new FilterEncodingService();
+        var result = filterEncodingService.DecodeFilters(base64String);
+        return result.IsSuccess;
     }
 }

--- a/Shopilent.API/Program.cs
+++ b/Shopilent.API/Program.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Scalar.AspNetCore;
+using Shopilent.API.Common.Services;
 using Shopilent.Application.Extensions;
 using Shopilent.Infrastructure.Cache.Redis.Extensions;
 using Shopilent.Infrastructure.Extensions;
@@ -26,9 +27,11 @@ builder.Services.AddStorageServices(builder.Configuration);
 builder.Services.AddPaymentServices(builder.Configuration);
 builder.Services.AddMeilisearch(builder.Configuration);
 
+builder.Services.AddSingleton<IFilterEncodingService, FilterEncodingService>();
+
 builder.Services.AddMediatR(cfg =>
 {
-    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly); // Register API assembly
+    cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
 });
 
 builder.Services.AddFastEndpoints();


### PR DESCRIPTION
- Added `ProductFilters` model to standardize filter representation.
- Implemented `FilterEncodingService` to handle base64 encoding and decoding of filters.
- Refactored `UniversalSearchEndpointV1` and `GetPaginatedProductsEndpointV1` to use the encoded filters for query execution.
- Replaced individual filter parameters with a single `FiltersBase64` property in request models.
- Updated validators and endpoints to validate and decode the base64 filters.