### PR TITLE
Replace `CategoryIds` with `CategorySlugs` across APIs, services, and search logic

### DIFF
--- a/Shopilent.API/Common/Models/ProductFilters.cs
+++ b/Shopilent.API/Common/Models/ProductFilters.cs
@@ -7,8 +7,8 @@ public class ProductFilters
     [JsonPropertyName("attributeFilters")]
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
 
-    [JsonPropertyName("categoryIds")]
-    public Guid[] CategoryIds { get; init; } = [];
+    [JsonPropertyName("categorySlugs")]
+    public string[] CategorySlugs { get; init; } = [];
 
     [JsonPropertyName("priceMin")]
     public decimal? PriceMin { get; init; }
@@ -36,9 +36,6 @@ public class ProductFilters
 
     [JsonPropertyName("sortDescending")]
     public bool SortDescending { get; init; } = false;
-
-    [JsonPropertyName("categoryId")]
-    public Guid? CategoryId { get; init; }
 
     [JsonPropertyName("sortColumn")]
     public string SortColumn { get; init; } = "Name";

--- a/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsEndpointV1.cs
@@ -61,13 +61,12 @@ public class GetPaginatedProductsEndpointV1 :
             PageSize = filters.PageSize,
             SortColumn = filters.SortColumn,
             SortDescending = filters.SortDescending,
-            CategoryId = filters.CategoryId,
             IsActiveOnly = filters.ActiveOnly,
             SearchQuery = filters.SearchQuery,
             AttributeFilters = filters.AttributeFilters,
             PriceMin = filters.PriceMin,
             PriceMax = filters.PriceMax,
-            CategoryIds = filters.CategoryIds,
+            CategorySlugs = filters.CategorySlugs,
             InStockOnly = filters.InStockOnly
         };
 

--- a/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Catalog/Products/GetPaginatedProducts/V1/GetPaginatedProductsRequestValidatorV1.cs
@@ -37,6 +37,27 @@ public class GetPaginatedProductsRequestValidatorV1 : Validator<GetPaginatedProd
 
         var filterEncodingService = new FilterEncodingService();
         var result = filterEncodingService.DecodeFilters(base64String);
-        return result.IsSuccess;
+        
+        if (result.IsFailure)
+            return false;
+            
+        var filters = result.Value;
+        if (filters.CategorySlugs?.Any() == true)
+        {
+            foreach (var slug in filters.CategorySlugs)
+            {
+                if (!IsValidSlugFormat(slug))
+                    return false;
+            }
+        }
+        
+        return true;
+    }
+    
+    private bool IsValidSlugFormat(string slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+            return false;
+        return System.Text.RegularExpressions.Regex.IsMatch(slug, @"^[a-z0-9]+(-[a-z0-9]+)*$");
     }
 }

--- a/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchEndpointV1.cs
@@ -56,7 +56,7 @@ public class UniversalSearchEndpointV1 : Endpoint<UniversalSearchRequestV1, ApiR
 
         var query = new UniversalSearchQueryV1(
             filters.SearchQuery,
-            filters.CategoryIds,
+            filters.CategorySlugs,
             filters.AttributeFilters,
             filters.PriceMin,
             filters.PriceMax,

--- a/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestValidatorV1.cs
+++ b/Shopilent.API/Endpoints/Search/UniversalSearch/V1/UniversalSearchRequestValidatorV1.cs
@@ -37,6 +37,28 @@ public class UniversalSearchRequestValidatorV1 : Validator<UniversalSearchReques
 
         var filterEncodingService = new FilterEncodingService();
         var result = filterEncodingService.DecodeFilters(base64String);
-        return result.IsSuccess;
+        
+        if (result.IsFailure)
+            return false;
+            
+        var filters = result.Value;
+        if (filters.CategorySlugs?.Any() == true)
+        {
+            foreach (var slug in filters.CategorySlugs)
+            {
+                if (!IsValidSlugFormat(slug))
+                    return false;
+            }
+        }
+        
+        return true;
+    }
+    
+    private bool IsValidSlugFormat(string slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+            return false;
+            
+        return System.Text.RegularExpressions.Regex.IsMatch(slug, @"^[a-z0-9]+(-[a-z0-9]+)*$");
     }
 }

--- a/Shopilent.Application/Abstractions/Search/ISearchService.cs
+++ b/Shopilent.Application/Abstractions/Search/ISearchService.cs
@@ -16,7 +16,5 @@ public interface ISearchService
     
     Task<Result<SearchResponse<ProductSearchResultDto>>> SearchProductsAsync(SearchRequest request, CancellationToken cancellationToken = default);
     
-    Task<Result<PaginatedResult<ProductDto>>> GetProductsAsync(ProductListingRequest request, CancellationToken cancellationToken = default);
-    
     Task<bool> IsHealthyAsync(CancellationToken cancellationToken = default);
 }

--- a/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
+++ b/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
@@ -25,6 +25,7 @@ public partial class ProductSearchDocument
     public ProductSearchPriceRange PriceRange { get; init; } = new();
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
     public Guid[] CategoryIds { get; init; } = [];
+    public string[] CategorySlugs { get; init; } = [];
     public string[] VariantSKUs { get; init; } = [];
     public bool HasStock { get; init; }
     public int TotalStock { get; init; }
@@ -106,6 +107,7 @@ public partial class ProductSearchDocument
             PriceRange = priceRange,
             AttributeFilters = attributeFilters,
             CategoryIds = categories.Select(c => c.Id).ToArray(),
+            CategorySlugs = categories.Where(c => !string.IsNullOrEmpty(c.Slug)).Select(c => c.Slug!).ToArray(),
             VariantSKUs = variants.Where(v => !string.IsNullOrEmpty(v.Sku)).Select(v => v.Sku!).ToArray(),
             HasStock = hasStock,
             TotalStock = totalStock,

--- a/Shopilent.Application/Abstractions/Search/SearchRequest.cs
+++ b/Shopilent.Application/Abstractions/Search/SearchRequest.cs
@@ -3,7 +3,7 @@ namespace Shopilent.Application.Abstractions.Search;
 public class SearchRequest
 {
     public string Query { get; init; } = "";
-    public Guid[] CategoryIds { get; init; } = [];
+    public string[] CategorySlugs { get; init; } = [];
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
     public decimal? PriceMin { get; init; }
     public decimal? PriceMax { get; init; }

--- a/Shopilent.Application/Abstractions/Search/SearchResponse.cs
+++ b/Shopilent.Application/Abstractions/Search/SearchResponse.cs
@@ -24,6 +24,7 @@ public class CategoryFacet
 {
     public Guid Id { get; init; }
     public string Name { get; init; } = "";
+    public string Slug { get; init; } = "";
     public int Count { get; init; }
 }
 

--- a/Shopilent.Application/Features/Catalog/Queries/GetPaginatedProducts/V1/GetPaginatedProductsQueryHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Queries/GetPaginatedProducts/V1/GetPaginatedProductsQueryHandlerV1.cs
@@ -29,7 +29,7 @@ internal sealed class GetPaginatedProductsQueryHandlerV1 :
             var searchRequest = new SearchRequest
             {
                 Query = request.SearchQuery ?? "",
-                CategoryIds = request.CategoryIds,
+                CategorySlugs = request.CategorySlugs,
                 AttributeFilters = request.AttributeFilters,
                 PriceMin = request.PriceMin,
                 PriceMax = request.PriceMax,

--- a/Shopilent.Application/Features/Catalog/Queries/GetPaginatedProducts/V1/GetPaginatedProductsQueryV1.cs
+++ b/Shopilent.Application/Features/Catalog/Queries/GetPaginatedProducts/V1/GetPaginatedProductsQueryV1.cs
@@ -12,18 +12,17 @@ public sealed record GetPaginatedProductsQueryV1 :
     public int PageSize { get; init; } = 10;
     public string SortColumn { get; init; } = "Name";
     public bool SortDescending { get; init; } = false;
-    public Guid? CategoryId { get; init; }
     public bool IsActiveOnly { get; init; } = true;
     
     public string SearchQuery { get; init; } = "";
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
     public decimal? PriceMin { get; init; }
     public decimal? PriceMax { get; init; }
-    public Guid[] CategoryIds { get; init; } = [];
+    public string[] CategorySlugs { get; init; } = [];
     public bool InStockOnly { get; init; } = false;
 
     public string CacheKey =>
-        $"products-page-{PageNumber}-size-{PageSize}-sort-{SortColumn}-{SortDescending}-category-{CategoryId}-active-{IsActiveOnly}-search-{SearchQuery.GetHashCode()}-filters-{GetAttributeFiltersHash()}-price-{PriceMin}-{PriceMax}-categories-{string.Join(",", CategoryIds)}-stock-{InStockOnly}";
+        $"products-page-{PageNumber}-size-{PageSize}-sort-{SortColumn}-{SortDescending}-active-{IsActiveOnly}-search-{SearchQuery.GetHashCode()}-filters-{GetAttributeFiltersHash()}-price-{PriceMin}-{PriceMax}-categories-{string.Join(",", CategorySlugs)}-stock-{InStockOnly}";
 
     public TimeSpan? Expiration => TimeSpan.FromMinutes(15);
     

--- a/Shopilent.Application/Features/Search/Queries/UniversalSearch/V1/UniversalSearchQueryHandlerV1.cs
+++ b/Shopilent.Application/Features/Search/Queries/UniversalSearch/V1/UniversalSearchQueryHandlerV1.cs
@@ -30,7 +30,7 @@ internal sealed class UniversalSearchQueryHandlerV1 : IQueryHandler<UniversalSea
             var searchRequest = new SearchRequest
             {
                 Query = request.Query,
-                CategoryIds = request.CategoryIds,
+                CategorySlugs = request.CategorySlugs,
                 AttributeFilters = request.AttributeFilters,
                 PriceMin = request.PriceMin,
                 PriceMax = request.PriceMax,

--- a/Shopilent.Application/Features/Search/Queries/UniversalSearch/V1/UniversalSearchQueryV1.cs
+++ b/Shopilent.Application/Features/Search/Queries/UniversalSearch/V1/UniversalSearchQueryV1.cs
@@ -6,7 +6,7 @@ namespace Shopilent.Application.Features.Search.Queries.UniversalSearch.V1;
 
 public record UniversalSearchQueryV1(
     string Query = "",
-    Guid[] CategoryIds = default!,
+    string[] CategorySlugs = default!,
     Dictionary<string, string[]> AttributeFilters = default!,
     decimal? PriceMin = null,
     decimal? PriceMax = null,
@@ -18,5 +18,5 @@ public record UniversalSearchQueryV1(
     bool SortDescending = false
 ) : IQuery<SearchResponse<ProductSearchResultDto>>
 {
-    public UniversalSearchQueryV1() : this("", Array.Empty<Guid>(), new Dictionary<string, string[]>()) { }
+    public UniversalSearchQueryV1() : this("", Array.Empty<string>(), new Dictionary<string, string[]>()) { }
 }


### PR DESCRIPTION
- Updated models (`SearchRequest`, `UniversalSearchQueryV1`, `ProductFilters`) and handling logic to use `CategorySlugs` instead of `CategoryIds`.
- Modified `MeilisearchService` to replace `category_ids` with `category_slugs` in filters, facets, and search parameters.
- Refactored query handlers and endpoints to adapt new `CategorySlugs` field for search requests.
- Improved validators to validate slug format in `CategorySlugs`.