### PR TITLE
Remove `CategoryIds` and redundant `Url` property from search models

### DIFF
--- a/Shopilent.Application/Abstractions/Search/ProductListingRequest.cs
+++ b/Shopilent.Application/Abstractions/Search/ProductListingRequest.cs
@@ -12,6 +12,5 @@ public class ProductListingRequest
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
     public decimal? PriceMin { get; init; }
     public decimal? PriceMax { get; init; }
-    public Guid[] CategoryIds { get; init; } = [];
     public bool InStockOnly { get; init; } = false;
 }

--- a/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
+++ b/Shopilent.Application/Abstractions/Search/ProductSearchDocument.cs
@@ -24,7 +24,6 @@ public partial class ProductSearchDocument
     
     public ProductSearchPriceRange PriceRange { get; init; } = new();
     public Dictionary<string, string[]> AttributeFilters { get; init; } = new();
-    public Guid[] CategoryIds { get; init; } = [];
     public string[] CategorySlugs { get; init; } = [];
     public string[] VariantSKUs { get; init; } = [];
     public bool HasStock { get; init; }
@@ -86,7 +85,6 @@ public partial class ProductSearchDocument
                 }).ToArray() ?? [],
                 Images = v.Images?.Select(img => new ProductSearchImage
                 {
-                    Url = img.ImageKey ?? "",
                     ImageKey = img.ImageKey ?? "",
                     ThumbnailKey = img.ThumbnailKey ?? "",
                     AltText = img.AltText ?? "",
@@ -97,7 +95,6 @@ public partial class ProductSearchDocument
             
             Images = images.Select(img => new ProductSearchImage
             {
-                Url = img.ImageKey ?? "",
                 ImageKey = img.ImageKey ?? "",
                 ThumbnailKey = img.ThumbnailKey ?? "",
                 AltText = img.AltText ?? "",
@@ -112,7 +109,6 @@ public partial class ProductSearchDocument
             
             PriceRange = priceRange,
             AttributeFilters = attributeFilters,
-            CategoryIds = categories.Select(c => c.Id).ToArray(),
             CategorySlugs = categories.Where(c => !string.IsNullOrEmpty(c.Slug)).Select(c => c.Slug!).ToArray(),
             VariantSKUs = variants.Where(v => !string.IsNullOrEmpty(v.Sku)).Select(v => v.Sku!).ToArray(),
             HasStock = hasStock,
@@ -161,7 +157,6 @@ public class ProductSearchVariantAttribute
 
 public class ProductSearchImage
 {
-    public string Url { get; init; } = "";
     public string ImageKey { get; init; } = "";
     public string ThumbnailKey { get; init; } = "";
     public string AltText { get; init; } = "";


### PR DESCRIPTION
- Eliminated the unused `CategoryIds` property in `ProductSearchDocument` and `ProductListingRequest`.
- Removed redundant `Url` property from `ProductSearchImage`.