### PR TITLE
Add `SearchSetupEndpointV1` for search initialization and indexing

### DIFF
--- a/Shopilent.API/Endpoints/Search/SearchSetup/V1/SearchSetupEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Search/SearchSetup/V1/SearchSetupEndpointV1.cs
@@ -1,0 +1,63 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Common.Constants;
+using Shopilent.Application.Features.Search.Commands.SearchSetup.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Search.SearchSetup.V1;
+
+public class SearchSetupEndpointV1 : Endpoint<SearchSetupRequestV1, ApiResponse<SearchSetupResponseV1>>
+{
+    private readonly ISender _sender;
+
+    public SearchSetupEndpointV1(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    public override void Configure()
+    {
+        Post("v1/admin/search/setup");
+        Policies(nameof(AuthorizationPolicy.RequireAdminOrManager));
+        Description(b => b
+            .WithName("SearchSetup")
+            .Produces<ApiResponse<SearchSetupResponseV1>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<SearchSetupResponseV1>>(StatusCodes.Status500InternalServerError)
+            .WithTags("Search", "Admin"));
+    }
+
+    public override async Task HandleAsync(SearchSetupRequestV1 req, CancellationToken ct)
+    {
+        var command = new SearchSetupCommandV1
+        {
+            InitializeIndexes = req.InitializeIndexes,
+            IndexProducts = req.IndexProducts,
+            ForceReindex = req.ForceReindex
+        };
+
+        var result = await _sender.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var statusCode = result.Error.Type switch
+            {
+                ErrorType.Validation => StatusCodes.Status400BadRequest,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            var errorResponse = ApiResponse<SearchSetupResponseV1>.Failure(
+                result.Error.Message,
+                statusCode);
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        var apiResponse = ApiResponse<SearchSetupResponseV1>.Success(
+            result.Value,
+            result.Value.Message);
+
+        await SendAsync(apiResponse, StatusCodes.Status200OK, ct);
+    }
+}

--- a/Shopilent.API/Endpoints/Search/SearchSetup/V1/SearchSetupRequestV1.cs
+++ b/Shopilent.API/Endpoints/Search/SearchSetup/V1/SearchSetupRequestV1.cs
@@ -1,0 +1,8 @@
+namespace Shopilent.API.Endpoints.Search.SearchSetup.V1;
+
+public class SearchSetupRequestV1
+{
+    public bool InitializeIndexes { get; init; } = true;
+    public bool IndexProducts { get; init; } = true;
+    public bool ForceReindex { get; init; } = false;
+}

--- a/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupCommandHandlerV1.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Messaging;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Abstractions.Search;
+using Shopilent.Domain.Common.Results;
+
+namespace Shopilent.Application.Features.Search.Commands.SearchSetup.V1;
+
+internal sealed class SearchSetupCommandHandlerV1 : ICommandHandler<SearchSetupCommandV1, SearchSetupResponseV1>
+{
+    private readonly ISearchService _searchService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<SearchSetupCommandHandlerV1> _logger;
+
+    public SearchSetupCommandHandlerV1(
+        ISearchService searchService,
+        IUnitOfWork unitOfWork,
+        ILogger<SearchSetupCommandHandlerV1> logger)
+    {
+        _searchService = searchService;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result<SearchSetupResponseV1>> Handle(
+        SearchSetupCommandV1 request,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var response = new SearchSetupResponseV1 { CompletedAt = DateTime.UtcNow };
+
+        try
+        {
+            _logger.LogInformation("Starting search setup - Initialize: {Initialize}, Index: {Index}, Force: {Force}",
+                request.InitializeIndexes, request.IndexProducts, request.ForceReindex);
+
+            if (request.InitializeIndexes)
+            {
+                _logger.LogInformation("Initializing search indexes...");
+                await _searchService.InitializeIndexesAsync(cancellationToken);
+                response.IndexesInitialized = true;
+                _logger.LogInformation("Search indexes initialized successfully");
+            }
+
+            if (request.IndexProducts)
+            {
+                _logger.LogInformation("Starting product indexing...");
+
+                var productDtos = await _unitOfWork.ProductReader.ListAllAsync(cancellationToken);
+                var productDtoList = productDtos.ToList();
+
+                if (!productDtoList.Any())
+                {
+                    _logger.LogInformation("No products found to index");
+                    response.ProductsIndexed = 0;
+                }
+                else
+                {
+                    var searchDocuments = new List<ProductSearchDocument>();
+                    foreach (var productDto in productDtoList)
+                    {
+                        var product = await _unitOfWork.ProductReader.GetDetailByIdAsync(productDto.Id, cancellationToken);
+                        if (product != null)
+                        {
+                            searchDocuments.Add(ProductSearchDocument.FromProductDto(product));
+                        }
+                    }
+
+                    var indexResult = await _searchService.IndexProductsAsync(searchDocuments, cancellationToken);
+
+                    if (indexResult.IsFailure)
+                    {
+                        _logger.LogError("Failed to index products: {Error}", indexResult.Error.Message);
+                        stopwatch.Stop();
+
+                        response.IsSuccess = false;
+                        response.Message = $"Search setup partially completed. Index initialization: {(response.IndexesInitialized ? "Success" : "Skipped")}. Product indexing failed: {indexResult.Error.Message}";
+                        response.Duration = stopwatch.Elapsed;
+
+                        return Result.Failure<SearchSetupResponseV1>(indexResult.Error);
+                    }
+
+                    response.ProductsIndexed = searchDocuments.Count;
+                    _logger.LogInformation("Successfully indexed {Count} products", searchDocuments.Count);
+                }
+            }
+
+            stopwatch.Stop();
+
+            var messageParts = new List<string>();
+            if (request.InitializeIndexes)
+                messageParts.Add("indexes initialized");
+            if (request.IndexProducts)
+                messageParts.Add($"{response.ProductsIndexed} products indexed");
+
+            response.IsSuccess = true;
+            response.Message = $"Search setup completed successfully: {string.Join(", ", messageParts)}";
+            response.Duration = stopwatch.Elapsed;
+
+            _logger.LogInformation("Search setup completed successfully in {Duration}ms - Indexes: {Indexes}, Products: {Products}",
+                stopwatch.ElapsedMilliseconds, response.IndexesInitialized, response.ProductsIndexed);
+
+            return Result.Success(response);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Unexpected error during search setup");
+
+            response.IsSuccess = false;
+            response.Message = $"Search setup failed: {ex.Message}";
+            response.Duration = stopwatch.Elapsed;
+
+            return Result.Failure<SearchSetupResponseV1>(
+                Domain.Common.Errors.Error.Failure("Search.SetupFailed", response.Message));
+        }
+    }
+}

--- a/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupCommandV1.cs
+++ b/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupCommandV1.cs
@@ -1,0 +1,10 @@
+using Shopilent.Application.Abstractions.Messaging;
+
+namespace Shopilent.Application.Features.Search.Commands.SearchSetup.V1;
+
+public class SearchSetupCommandV1 : ICommand<SearchSetupResponseV1>
+{
+    public bool InitializeIndexes { get; init; } = true;
+    public bool IndexProducts { get; init; } = true;
+    public bool ForceReindex { get; init; } = false;
+}

--- a/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupResponseV1.cs
+++ b/Shopilent.Application/Features/Search/Commands/SearchSetup/V1/SearchSetupResponseV1.cs
@@ -1,0 +1,11 @@
+namespace Shopilent.Application.Features.Search.Commands.SearchSetup.V1;
+
+public class SearchSetupResponseV1
+{
+    public bool IsSuccess { get; set; }
+    public string Message { get; set; } = "";
+    public bool IndexesInitialized { get; set; }
+    public int ProductsIndexed { get; set; }
+    public DateTime CompletedAt { get; set; }
+    public TimeSpan Duration { get; set; }
+}


### PR DESCRIPTION
- Introduced `SearchSetupEndpointV1` for admin search setup operations.
- Added `SearchSetupCommandV1` and corresponding handler to support index initialization and product indexing.
- Implemented response and request models for better API communication.
- Enhanced logging and error handling for comprehensive operation monitoring.