### PR TITLE
Add `ClearAllCacheEndpointV1` for cache clearing operations

### DIFF
--- a/Shopilent.API/Endpoints/Administration/ClearAllCache/V1/ClearAllCacheEndpointV1.cs
+++ b/Shopilent.API/Endpoints/Administration/ClearAllCache/V1/ClearAllCacheEndpointV1.cs
@@ -1,0 +1,62 @@
+using FastEndpoints;
+using MediatR;
+using Shopilent.API.Common.Models;
+using Shopilent.Application.Common.Constants;
+using Shopilent.Application.Features.Administration.Commands.ClearAllCache.V1;
+using Shopilent.Domain.Common.Errors;
+
+namespace Shopilent.API.Endpoints.Administration.ClearAllCache.V1;
+
+public class ClearAllCacheEndpointV1 : EndpointWithoutRequest<ApiResponse<ClearAllCacheResponseV1>>
+{
+    private readonly IMediator _mediator;
+
+    public ClearAllCacheEndpointV1(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Delete("v1/administration/cache");
+        Description(b => b
+            .WithName("ClearAllCache")
+            .Produces<ApiResponse<ClearAllCacheResponseV1>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<string>>(StatusCodes.Status500InternalServerError)
+            .WithTags("Administration")
+            .WithSummary("Clear all Redis cache")
+            .WithDescription("Clears all cached data from Redis. This operation is restricted to administrators only."));
+        Policies(nameof(AuthorizationPolicy.RequireAdmin));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var command = new ClearAllCacheCommandV1();
+
+        var result = await _mediator.Send(command, ct);
+
+        if (result.IsFailure)
+        {
+            var errorResponse = new ApiResponse<ClearAllCacheResponseV1>
+            {
+                Succeeded = false,
+                Message = result.Error.Message,
+                StatusCode = StatusCodes.Status500InternalServerError,
+                Errors = new[] { result.Error.Message }
+            };
+
+            await SendAsync(errorResponse, errorResponse.StatusCode, ct);
+            return;
+        }
+
+        var response = new ApiResponse<ClearAllCacheResponseV1>
+        {
+            Succeeded = true,
+            Message = "Cache cleared successfully",
+            StatusCode = StatusCodes.Status200OK,
+            Data = result.Value
+        };
+
+        await SendAsync(response, response.StatusCode, ct);
+    }
+}

--- a/Shopilent.Application/Abstractions/Caching/ICacheService.cs
+++ b/Shopilent.Application/Abstractions/Caching/ICacheService.cs
@@ -16,4 +16,5 @@ public interface ICacheService
     
     Task RemoveByPatternAsync(string pattern, CancellationToken cancellationToken = default);
 
+    Task<int> ClearAllAsync(CancellationToken cancellationToken = default);
 }

--- a/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheCommandHandlerV1.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+using Shopilent.Application.Abstractions.Caching;
+using Shopilent.Application.Abstractions.Messaging;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+
+namespace Shopilent.Application.Features.Administration.Commands.ClearAllCache.V1;
+
+internal sealed class ClearAllCacheCommandHandlerV1 : ICommandHandler<ClearAllCacheCommandV1, ClearAllCacheResponseV1>
+{
+    private readonly ICacheService _cacheService;
+    private readonly ILogger<ClearAllCacheCommandHandlerV1> _logger;
+
+    public ClearAllCacheCommandHandlerV1(
+        ICacheService cacheService,
+        ILogger<ClearAllCacheCommandHandlerV1> logger)
+    {
+        _cacheService = cacheService;
+        _logger = logger;
+    }
+
+    public async Task<Result<ClearAllCacheResponseV1>> Handle(
+        ClearAllCacheCommandV1 request, 
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            _logger.LogInformation("Starting cache clear operation");
+
+            var keysCleared = await _cacheService.ClearAllAsync(cancellationToken);
+
+            var response = new ClearAllCacheResponseV1
+            {
+                Message = $"Successfully cleared all cache. {keysCleared} keys removed.",
+                ClearedAt = DateTime.UtcNow,
+                KeysCleared = keysCleared
+            };
+
+            _logger.LogInformation("Cache clear operation completed successfully. Keys cleared: {KeysCleared}", keysCleared);
+
+            return Result.Success(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while clearing cache");
+            
+            return Result.Failure<ClearAllCacheResponseV1>(
+                Error.Failure(
+                    code: "ClearAllCache.Failed",
+                    message: $"Failed to clear cache: {ex.Message}"));
+        }
+    }
+}

--- a/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheCommandV1.cs
+++ b/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheCommandV1.cs
@@ -1,0 +1,7 @@
+using Shopilent.Application.Abstractions.Messaging;
+
+namespace Shopilent.Application.Features.Administration.Commands.ClearAllCache.V1;
+
+public class ClearAllCacheCommandV1 : ICommand<ClearAllCacheResponseV1>
+{
+}

--- a/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheResponseV1.cs
+++ b/Shopilent.Application/Features/Administration/Commands/ClearAllCache/V1/ClearAllCacheResponseV1.cs
@@ -1,0 +1,8 @@
+namespace Shopilent.Application.Features.Administration.Commands.ClearAllCache.V1;
+
+public class ClearAllCacheResponseV1
+{
+    public string Message { get; set; } = string.Empty;
+    public DateTime ClearedAt { get; set; }
+    public int KeysCleared { get; set; }
+}

--- a/Shopilent.Infrastructure.Cache.Redis/Services/CacheService.cs
+++ b/Shopilent.Infrastructure.Cache.Redis/Services/CacheService.cs
@@ -153,6 +153,20 @@ internal class CacheService : ICacheService
             await _cache.RemoveAsync(keyName, cancellationToken);
         }
     }
+
+    public async Task<int> ClearAllAsync(CancellationToken cancellationToken = default)
+    {
+        var server = _redis.GetServer(_redis.GetEndPoints().First());
+        var keys = server.Keys(pattern: _redisSettings.Value.InstanceName + "*").ToList();
+
+        foreach (var key in keys)
+        {
+            var keyName = key.ToString().Replace(_redisSettings.Value.InstanceName, "");
+            await _cache.RemoveAsync(keyName, cancellationToken);
+        }
+
+        return keys.Count;
+    }
     
     private void NormalizeDictionaryProperties<T>(T obj)
     {


### PR DESCRIPTION
- Introduced `ClearAllCacheEndpointV1` to allow administrators to clear all Redis cache.
- Added `ClearAllCacheCommandV1` and its handler for cache clearing logic and error handling.
- Enhanced `CacheService` with a new `ClearAllAsync` method to remove all cache keys and return the count.