### PR TITLE
Move common project properties to `Directory.Build.props`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,12 @@
 <Project>
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(MSBuildProjectExtension)' != '.esproj'">
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(MSBuildProjectExtension)' != '.esproj'">
         <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Shopilent-API.sln
+++ b/Shopilent-API.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		compose.yaml = compose.yaml
 		README.md = README.md
 		.env.example = .env.example
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0EA014D9-5D23-4EE2-A0E5-B6A0916000CD}"

--- a/Shopilent.API/Shopilent.API.csproj
+++ b/Shopilent.API/Shopilent.API.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <UserSecretsId>aca58440-5cca-4621-ada1-6e32f9c93750</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,11 +34,6 @@
       <ProjectReference Include="..\Shopilent.Infrastructure.S3ObjectStorage\Shopilent.Infrastructure.S3ObjectStorage.csproj" />
       <ProjectReference Include="..\Shopilent.Infrastructure.Search.Meilisearch\Shopilent.Infrastructure.Search.Meilisearch.csproj" />
       <ProjectReference Include="..\Shopilent.Infrastructure\Shopilent.Infrastructure.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Endpoints\Catalog\Attributes\" />
-      <Folder Include="Endpoints\Catalog\Categories\" />
     </ItemGroup>
 
 </Project>

--- a/Shopilent.Application.UnitTests/Shopilent.Application.UnitTests.csproj
+++ b/Shopilent.Application.UnitTests/Shopilent.Application.UnitTests.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Shopilent.Application/Shopilent.Application.csproj
+++ b/Shopilent.Application/Shopilent.Application.csproj
@@ -1,37 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Shopilent.Domain\Shopilent.Domain.csproj" />
+        <ProjectReference Include="..\Shopilent.Domain\Shopilent.Domain.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Common\Behaviors\" />
-      <Folder Include="Common\Interfaces\Services\" />
-      <Folder Include="Features\Audit\Commands\" />
-      <Folder Include="Features\Audit\Queries\" />
-      <Folder Include="Features\Identity\Commands\Password\V1\" />
-      <Folder Include="Features\Identity\Queries\" />
-      <Folder Include="Features\Payments\Commands\" />
-      <Folder Include="Features\Payments\Queries\" />
-      <Folder Include="Features\Sales\Commands\" />
-      <Folder Include="Features\Sales\Queries\" />
-      <Folder Include="Features\Shipping\Commands\" />
-      <Folder Include="Features\Shipping\Queries\" />
+        <Folder Include="Features\Audit\Commands\"/>
+        <Folder Include="Features\Audit\Queries\"/>
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.11.0" />
-      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-      <PackageReference Include="MediatR" Version="12.4.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-      <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="FluentValidation" Version="11.11.0"/>
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0"/>
+        <PackageReference Include="MediatR" Version="12.4.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3"/>
+        <PackageReference Include="Serilog" Version="4.2.0"/>
     </ItemGroup>
-
 </Project>

--- a/Shopilent.Domain.UnitTests/Shopilent.Domain.UnitTests.csproj
+++ b/Shopilent.Domain.UnitTests/Shopilent.Domain.UnitTests.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <RootNamespace>Shopilent.Domain.Tests</RootNamespace>
     </PropertyGroup>

--- a/Shopilent.Domain/Shopilent.Domain.csproj
+++ b/Shopilent.Domain/Shopilent.Domain.csproj
@@ -1,9 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
 </Project>

--- a/Shopilent.Infrastructure.Cache.Redis/Shopilent.Infrastructure.Cache.Redis.csproj
+++ b/Shopilent.Infrastructure.Cache.Redis/Shopilent.Infrastructure.Cache.Redis.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj" />

--- a/Shopilent.Infrastructure.Identity/Shopilent.Infrastructure.Identity.csproj
+++ b/Shopilent.Infrastructure.Identity/Shopilent.Infrastructure.Identity.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj" />

--- a/Shopilent.Infrastructure.Logging/Shopilent.Infrastructure.Logging.csproj
+++ b/Shopilent.Infrastructure.Logging/Shopilent.Infrastructure.Logging.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Serilog" Version="4.2.0" />

--- a/Shopilent.Infrastructure.Payments/Shopilent.Infrastructure.Payments.csproj
+++ b/Shopilent.Infrastructure.Payments/Shopilent.Infrastructure.Payments.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj" />

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Shopilent.Infrastructure.Persistence.PostgreSQL.csproj
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Shopilent.Infrastructure.Persistence.PostgreSQL.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />

--- a/Shopilent.Infrastructure.Realtime.SignalR/Shopilent.Infrastructure.Realtime.SignalR.csproj
+++ b/Shopilent.Infrastructure.Realtime.SignalR/Shopilent.Infrastructure.Realtime.SignalR.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.SignalR" Version="9.0.0" />

--- a/Shopilent.Infrastructure.S3ObjectStorage/Shopilent.Infrastructure.S3ObjectStorage.csproj
+++ b/Shopilent.Infrastructure.S3ObjectStorage/Shopilent.Infrastructure.S3ObjectStorage.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj" />

--- a/Shopilent.Infrastructure.Search.Meilisearch/Shopilent.Infrastructure.Search.Meilisearch.csproj
+++ b/Shopilent.Infrastructure.Search.Meilisearch/Shopilent.Infrastructure.Search.Meilisearch.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="MeiliSearch" Version="0.16.0" />

--- a/Shopilent.Infrastructure/Shopilent.Infrastructure.csproj
+++ b/Shopilent.Infrastructure/Shopilent.Infrastructure.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj" />


### PR DESCRIPTION
- Created `Directory.Build.props` to centralize shared project configurations.
- Removed duplicate `TargetFramework`, `Nullable`, and `ImplicitUsings` properties from individual `.csproj` files.
- Added `SonarAnalyzer.CSharp` as a shared analyzer package for all projects.