### PR TITLE
Add `JsonDictionaryTypeHandler` for JSONB mapping in Dapper

### DIFF
--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Configuration/Extensions/PostgresServiceCollectionExtensions.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Configuration/Extensions/PostgresServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using System.Data;
+using Dapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
+using Shopilent.Infrastructure.Persistence.PostgreSQL.Dapper.TypeHandlers;
 using Shopilent.Application.Abstractions.Persistence;
 using Shopilent.Domain.Audit.Repositories.Read;
 using Shopilent.Domain.Audit.Repositories.Write;
@@ -50,6 +52,9 @@ public static class PostgresServiceCollectionExtensions
         };
         services.AddSingleton(connectionConfig);
 
+        // Register Dapper type handlers for automatic JSONB conversion
+        SqlMapper.AddTypeHandler(new JsonDictionaryTypeHandler());
+
         services.AddScoped<AuditSaveChangesInterceptor>();
 
         services.AddDbContext<ApplicationDbContext>((sp, options) =>
@@ -77,6 +82,7 @@ public static class PostgresServiceCollectionExtensions
         AddReadRepositories(services);
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
+
         // Register health checks
         services.AddHealthChecks(configuration);
 

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Dapper/TypeHandlers/JsonDictionaryTypeHandler.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Dapper/TypeHandlers/JsonDictionaryTypeHandler.cs
@@ -1,0 +1,74 @@
+using System.Data;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Dapper;
+
+namespace Shopilent.Infrastructure.Persistence.PostgreSQL.Dapper.TypeHandlers;
+
+public class JsonDictionaryTypeHandler : SqlMapper.TypeHandler<Dictionary<string, object>>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public override Dictionary<string, object> Parse(object value)
+    {
+        if (value == null || value == DBNull.Value)
+        {
+            return new Dictionary<string, object>();
+        }
+
+        var jsonString = value.ToString();
+        if (string.IsNullOrWhiteSpace(jsonString))
+        {
+            return new Dictionary<string, object>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(jsonString, JsonOptions)
+                   ?? new Dictionary<string, object>();
+        }
+        catch (JsonException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to deserialize JSON metadata: {ex.Message}. JSON: {jsonString}");
+            return new Dictionary<string, object>();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Unexpected error deserializing JSON metadata: {ex.Message}");
+            return new Dictionary<string, object>();
+        }
+    }
+
+    public override void SetValue(IDbDataParameter parameter, Dictionary<string, object> value)
+    {
+        if (value == null || value.Count == 0)
+        {
+            parameter.Value = "{}";
+        }
+        else
+        {
+            try
+            {
+                parameter.Value = JsonSerializer.Serialize(value, JsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to serialize dictionary to JSON: {ex.Message}");
+                parameter.Value = "{}";
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Unexpected error serializing dictionary: {ex.Message}");
+                parameter.Value = "{}";
+            }
+        }
+
+        parameter.DbType = DbType.String;
+    }
+}


### PR DESCRIPTION
- Introduced custom `JsonDictionaryTypeHandler` to handle JSONB serialization and deserialization for `Dictionary<string, object>`.
- Updated `PostgresServiceCollectionExtensions` to register the type handler for automatic JSON conversion in Dapper queries.