### PR TITLE
Replace `SaveEntitiesAsync` with `SaveChangesAsync` across repositories and handlers

### DIFF
--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateCategoryCommandTests.cs
@@ -82,7 +82,7 @@ public class CreateCategoryCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -111,7 +111,7 @@ public class CreateCategoryCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteCategoryCommandTests.cs
@@ -87,7 +87,7 @@ public class DeleteCategoryCommandTests : TestBase
             
         // Verify the changes were saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -121,7 +121,7 @@ public class DeleteCategoryCommandTests : TestBase
             
         // Verify the changes were not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -172,7 +172,7 @@ public class DeleteCategoryCommandTests : TestBase
             
         // Verify the changes were not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -228,7 +228,7 @@ public class DeleteCategoryCommandTests : TestBase
             
         // Verify the changes were not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryCommandTests.cs
@@ -83,7 +83,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -114,7 +114,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -156,7 +156,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -182,7 +182,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -230,7 +230,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -277,7 +277,7 @@ public class UpdateCategoryCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
 }

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryParentCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryParentCommandTests.cs
@@ -96,7 +96,7 @@ public class UpdateCategoryParentCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -148,7 +148,7 @@ public class UpdateCategoryParentCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -179,7 +179,7 @@ public class UpdateCategoryParentCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -220,7 +220,7 @@ public class UpdateCategoryParentCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -256,7 +256,7 @@ public class UpdateCategoryParentCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
 }

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateCategoryStatusCommandTests.cs
@@ -75,7 +75,7 @@ public class UpdateCategoryStatusCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -116,7 +116,7 @@ public class UpdateCategoryStatusCommandTests : TestBase
         
         // Verify the category was saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -146,7 +146,7 @@ public class UpdateCategoryStatusCommandTests : TestBase
         
         // Verify the category was not saved
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Never);
     }
     
@@ -187,7 +187,7 @@ public class UpdateCategoryStatusCommandTests : TestBase
         
         // Verify the category was saved (even though no real change occurred)
         Fixture.MockUnitOfWork.Verify(
-            uow => uow.SaveEntitiesAsync(CancellationToken), 
+            uow => uow.SaveChangesAsync(CancellationToken), 
             Times.Once);
     }
     
@@ -214,9 +214,9 @@ public class UpdateCategoryStatusCommandTests : TestBase
             .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
             .ReturnsAsync(category);
             
-        // Make SaveEntitiesAsync throw an exception
+        // Make SaveChangesAsync throw an exception
         Fixture.MockUnitOfWork
-            .Setup(uow => uow.SaveEntitiesAsync(CancellationToken))
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
             .ThrowsAsync(new Exception("Test exception"));
             
         // Act

--- a/Shopilent.Application.UnitTests/Testing/TestFixture.cs
+++ b/Shopilent.Application.UnitTests/Testing/TestFixture.cs
@@ -131,9 +131,6 @@ public class TestFixture
         // Setup default save changes to return success
         MockUnitOfWork.Setup(uow => uow.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
-        
-        MockUnitOfWork.Setup(uow => uow.SaveEntitiesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
             
         // Set up basic CurrentUserContext behaviors
         MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);

--- a/Shopilent.Application/Abstractions/Persistence/IUnitOfWork.cs
+++ b/Shopilent.Application/Abstractions/Persistence/IUnitOfWork.cs
@@ -58,15 +58,12 @@ public interface IUnitOfWork : IDisposable
 
     IAuditLogReadRepository AuditLogReader { get; }
     IAuditLogWriteRepository AuditLogWriter { get; }
-    
+
     IOutboxMessageWriteRepository OutboxMessageWriteWriter { get; }
 
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
-    Task<bool> SaveEntitiesAsync(CancellationToken cancellationToken = default);
-
     Task BeginTransactionAsync(CancellationToken cancellationToken = default);
     Task CommitTransactionAsync(CancellationToken cancellationToken = default);
-
     Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
 }

--- a/Shopilent.Application/Features/Catalog/Commands/AddProductVariant/V1/AddProductVariantCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/AddProductVariant/V1/AddProductVariantCommandHandlerV1.cs
@@ -194,7 +194,7 @@ internal sealed class
             await _unitOfWork.ProductVariantWriter.AddAsync(variant, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var attributeDtos = attributeValues.Select(a => new VariantAttributeDto

--- a/Shopilent.Application/Features/Catalog/Commands/CreateAttribute/V1/CreateAttributeCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/CreateAttribute/V1/CreateAttributeCommandHandlerV1.cs
@@ -79,7 +79,7 @@ internal sealed class CreateAttributeCommandHandlerV1 : ICommandHandler<CreateAt
             await _unitOfWork.AttributeWriter.AddAsync(attribute, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var response = new CreateAttributeResponseV1

--- a/Shopilent.Application/Features/Catalog/Commands/CreateCategory/V1/CreateCategoryCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/CreateCategory/V1/CreateCategoryCommandHandlerV1.cs
@@ -83,7 +83,7 @@ internal sealed class
             await _unitOfWork.CategoryWriter.AddAsync(category, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var response = new CreateCategoryResponseV1

--- a/Shopilent.Application/Features/Catalog/Commands/CreateProduct/V1/CreateProductCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/CreateProduct/V1/CreateProductCommandHandlerV1.cs
@@ -195,7 +195,7 @@ internal sealed class CreateProductCommandHandlerV1 : ICommandHandler<CreateProd
             await _unitOfWork.ProductWriter.AddAsync(product, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response with category IDs
             var categoryIds = product.Categories.Select(pc => pc.CategoryId).ToList();

--- a/Shopilent.Application/Features/Catalog/Commands/DeleteAttribute/V1/DeleteAttributeCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/DeleteAttribute/V1/DeleteAttributeCommandHandlerV1.cs
@@ -49,7 +49,7 @@ internal sealed class DeleteAttributeCommandHandlerV1 : ICommandHandler<DeleteAt
             await _unitOfWork.AttributeWriter.DeleteAsync(attribute, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Attribute deleted successfully with ID: {AttributeId}", attribute.Id);
 

--- a/Shopilent.Application/Features/Catalog/Commands/DeleteCategory/V1/DeleteCategoryCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/DeleteCategory/V1/DeleteCategoryCommandHandlerV1.cs
@@ -54,7 +54,7 @@ internal sealed class DeleteCategoryCommandHandlerV1 : ICommandHandler<DeleteCat
             await _unitOfWork.CategoryWriter.DeleteAsync(category, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Category deleted successfully with ID: {CategoryId}", category.Id);
 

--- a/Shopilent.Application/Features/Catalog/Commands/DeleteProduct/V1/DeleteProductCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/DeleteProduct/V1/DeleteProductCommandHandlerV1.cs
@@ -40,7 +40,7 @@ internal sealed class DeleteProductCommandHandlerV1 : ICommandHandler<DeleteProd
             await _unitOfWork.ProductWriter.DeleteAsync(product, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Product deleted successfully with ID: {ProductId}", product.Id);
 

--- a/Shopilent.Application/Features/Catalog/Commands/DeleteProductVariant/V1/DeleteProductVariantCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/DeleteProductVariant/V1/DeleteProductVariantCommandHandlerV1.cs
@@ -42,7 +42,7 @@ internal sealed class DeleteProductVariantCommandHandlerV1 : ICommandHandler<Del
             await _unitOfWork.ProductVariantWriter.DeleteAsync(variant, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Product variant with ID {VariantId} deleted successfully", request.Id);
 

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateAttribute/V1/UpdateAttributeCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateAttribute/V1/UpdateAttributeCommandHandlerV1.cs
@@ -83,7 +83,7 @@ internal sealed class
 
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var response = new UpdateAttributeResponseV1

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateCategory/V1/UpdateCategoryCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateCategory/V1/UpdateCategoryCommandHandlerV1.cs
@@ -80,7 +80,7 @@ internal sealed class UpdateCategoryCommandHandlerV1 : ICommandHandler<UpdateCat
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var response = new UpdateCategoryResponseV1

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateCategoryParent/V1/UpdateCategoryParentCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateCategoryParent/V1/UpdateCategoryParentCommandHandlerV1.cs
@@ -68,7 +68,7 @@ internal sealed class UpdateCategoryParentCommandHandlerV1 : ICommandHandler<Upd
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Get parent name if applicable
             string parentName = null;

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateCategoryStatus/V1/UpdateCategoryStatusCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateCategoryStatus/V1/UpdateCategoryStatusCommandHandlerV1.cs
@@ -58,7 +58,7 @@ internal sealed class UpdateCategoryStatusCommandHandlerV1 : ICommandHandler<Upd
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Category status updated successfully. ID: {CategoryId}, IsActive: {IsActive}", 
                 category.Id, request.IsActive);

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateProduct/V1/UpdateProductCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateProduct/V1/UpdateProductCommandHandlerV1.cs
@@ -348,7 +348,7 @@ internal sealed class UpdateProductCommandHandlerV1 : ICommandHandler<UpdateProd
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Get updated category IDs
             var categoryIds = product.Categories.Select(pc => pc.CategoryId).ToList();

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateProductStatus/V1/UpdateProductStatusCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateProductStatus/V1/UpdateProductStatusCommandHandlerV1.cs
@@ -58,7 +58,7 @@ internal sealed class UpdateProductStatusCommandHandlerV1 : ICommandHandler<Upda
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Product status updated successfully. ID: {ProductId}, IsActive: {IsActive}", 
                 product.Id, request.IsActive);

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateVariant/V1/UpdateVariantCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateVariant/V1/UpdateVariantCommandHandlerV1.cs
@@ -285,7 +285,7 @@ internal sealed class UpdateVariantCommandHandlerV1 : ICommandHandler<UpdateVari
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Map images for response
             var images = variant.Images.Select(img => new VariantImageResponseDto

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateVariantStatus/V1/UpdateVariantStatusCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateVariantStatus/V1/UpdateVariantStatusCommandHandlerV1.cs
@@ -60,7 +60,7 @@ internal sealed class UpdateVariantStatusCommandHandlerV1 : ICommandHandler<Upda
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Variant status updated successfully. ID: {VariantId}, IsActive: {IsActive}", 
                 variant.Id, request.IsActive);

--- a/Shopilent.Application/Features/Catalog/Commands/UpdateVariantStock/V1/UpdateVariantStockCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Catalog/Commands/UpdateVariantStock/V1/UpdateVariantStockCommandHandlerV1.cs
@@ -49,7 +49,7 @@ internal sealed class UpdateVariantStockCommandHandlerV1 : ICommandHandler<Updat
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Create response
             var response = new UpdateVariantStockResponseV1

--- a/Shopilent.Application/Features/Identity/Commands/ChangeUserRole/V1/ChangeUserRoleCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Identity/Commands/ChangeUserRole/V1/ChangeUserRoleCommandHandlerV1.cs
@@ -49,7 +49,7 @@ internal sealed class ChangeUserRoleCommandHandlerV1 : ICommandHandler<ChangeUse
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Successfully changed role for user {UserId} to {NewRole}",
                 request.UserId, request.NewRole);

--- a/Shopilent.Application/Features/Identity/Commands/UpdateUserProfile/V1/UpdateUserProfileCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Identity/Commands/UpdateUserProfile/V1/UpdateUserProfileCommandHandlerV1.cs
@@ -71,7 +71,7 @@ internal sealed class
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("User profile updated successfully. UserId: {UserId}", user.Id);
 

--- a/Shopilent.Application/Features/Identity/Commands/UpdateUserStatus/V1/UpdateUserStatusCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Identity/Commands/UpdateUserStatus/V1/UpdateUserStatusCommandHandlerV1.cs
@@ -66,7 +66,7 @@ internal sealed class UpdateUserStatusCommandHandlerV1 : ICommandHandler<UpdateU
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("User status updated successfully. ID: {UserId}, IsActive: {IsActive}", 
                 user.Id, request.IsActive);

--- a/Shopilent.Application/Features/Identity/EventHandlers/UserLockedOutEventHandler.cs
+++ b/Shopilent.Application/Features/Identity/EventHandlers/UserLockedOutEventHandler.cs
@@ -67,7 +67,7 @@ public class UserLockedOutEventHandler : INotificationHandler<DomainEventNotific
                     }
 
                     // Save changes to persist token revocations
-                    await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                    await _unitOfWork.SaveChangesAsync(cancellationToken);
                 }
 
                 // Send lock notification email

--- a/Shopilent.Application/Features/Identity/EventHandlers/UserPasswordChangedEventHandler.cs
+++ b/Shopilent.Application/Features/Identity/EventHandlers/UserPasswordChangedEventHandler.cs
@@ -60,7 +60,7 @@ public class UserPasswordChangedEventHandler : INotificationHandler<DomainEventN
                     }
                     
                     // Save changes to persist token revocations
-                    await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                    await _unitOfWork.SaveChangesAsync(cancellationToken);
                 }
                 
                 // Send notification email

--- a/Shopilent.Application/Features/Identity/EventHandlers/UserStatusChangedEventHandler.cs
+++ b/Shopilent.Application/Features/Identity/EventHandlers/UserStatusChangedEventHandler.cs
@@ -89,7 +89,7 @@ public class UserStatusChangedEventHandler : INotificationHandler<DomainEventNot
                         }
                         
                         // Save changes to persist token revocations
-                        await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
                     }
                 }
             }

--- a/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Payments/Commands/AddPaymentMethod/V1/AddPaymentMethodCommandHandlerV1.cs
@@ -124,7 +124,7 @@ internal sealed class
 
             // Add to repository and save using Unit of Work
             await _unitOfWork.PaymentMethodWriter.AddAsync(paymentMethod, cancellationToken);
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Payment method created successfully: {PaymentMethodId} for user: {UserId}",
                 paymentMethod.Id, userId);
@@ -575,7 +575,7 @@ internal sealed class
 
             // Add to repository and save using Unit of Work
             await _unitOfWork.PaymentMethodWriter.AddAsync(paymentMethod, cancellationToken);
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(
                 "Payment method created successfully from confirmed setup intent: {PaymentMethodId} for user: {UserId}",

--- a/Shopilent.Application/Features/Payments/Commands/DeletePaymentMethod/V1/DeletePaymentMethodCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Payments/Commands/DeletePaymentMethod/V1/DeletePaymentMethodCommandHandlerV1.cs
@@ -91,7 +91,7 @@ internal sealed class DeletePaymentMethodCommandHandlerV1 : ICommandHandler<Dele
             await _unitOfWork.PaymentMethodWriter.DeleteAsync(paymentMethod, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Payment method deleted successfully. ID: {PaymentMethodId}, User: {UserId}",
                 paymentMethod.Id, currentUserId);

--- a/Shopilent.Application/Features/Payments/Commands/ProcessWebhook/V1/ProcessWebhookCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Payments/Commands/ProcessWebhook/V1/ProcessWebhookCommandHandlerV1.cs
@@ -130,7 +130,7 @@ public class ProcessWebhookCommandHandlerV1 : ICommandHandler<ProcessWebhookComm
                     break;
             }
 
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
             await _unitOfWork.CommitTransactionAsync(cancellationToken);
 
             _logger.LogInformation("Successfully processed webhook event {EventType} for transaction {TransactionId}",

--- a/Shopilent.Application/Features/Payments/EventHandlers/PaymentFailedEventHandler.cs
+++ b/Shopilent.Application/Features/Payments/EventHandlers/PaymentFailedEventHandler.cs
@@ -68,7 +68,7 @@ public class PaymentFailedEventHandler : INotificationHandler<DomainEventNotific
                         await _unitOfWork.OrderWriter.UpdateAsync(order, cancellationToken);
 
                         // Save changes to persist the updates
-                        await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
                     }
                     else
                     {

--- a/Shopilent.Application/Features/Payments/EventHandlers/PaymentRefundedEventHandler.cs
+++ b/Shopilent.Application/Features/Payments/EventHandlers/PaymentRefundedEventHandler.cs
@@ -63,7 +63,7 @@ public class PaymentRefundedEventHandler : INotificationHandler<DomainEventNotif
                         await _unitOfWork.OrderWriter.UpdateAsync(order, cancellationToken);
 
                         // Save changes to persist the updates
-                        await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
                     }
                     else
                     {

--- a/Shopilent.Application/Features/Payments/EventHandlers/PaymentSucceededEventHandler.cs
+++ b/Shopilent.Application/Features/Payments/EventHandlers/PaymentSucceededEventHandler.cs
@@ -62,7 +62,7 @@ public class PaymentSucceededEventHandler : INotificationHandler<DomainEventNoti
                         await _unitOfWork.OrderWriter.UpdateAsync(order, cancellationToken);
 
                         // Save changes to persist the updates
-                        await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
                     }
                     else
                     {

--- a/Shopilent.Application/Features/Sales/Commands/AssignCartToUser/V1/AssignCartToUserCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/AssignCartToUser/V1/AssignCartToUserCommandHandlerV1.cs
@@ -91,7 +91,7 @@ internal sealed class AssignCartToUserCommandHandlerV1 : ICommandHandler<AssignC
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Cart {CartId} successfully assigned to user {UserId}", 
                 request.CartId, userId);

--- a/Shopilent.Application/Features/Sales/Commands/CancelOrder/V1/CancelOrderCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/CancelOrder/V1/CancelOrderCommandHandlerV1.cs
@@ -61,7 +61,7 @@ internal sealed class CancelOrderCommandHandlerV1 : ICommandHandler<CancelOrderC
             await _unitOfWork.OrderWriter.UpdateAsync(order, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Successfully cancelled order {OrderId}", request.OrderId);
 

--- a/Shopilent.Application/Features/Sales/Commands/ClearCart/V1/ClearCartCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/ClearCart/V1/ClearCartCommandHandlerV1.cs
@@ -79,7 +79,7 @@ internal sealed class ClearCartCommandHandlerV1 : ICommandHandler<ClearCartComma
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Cart {CartId} successfully cleared for user {UserId}",
                 cart.Id, cart.UserId ?? Guid.Empty);

--- a/Shopilent.Application/Features/Sales/Commands/CreateOrderFromCart/V1/CreateOrderFromCartCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/CreateOrderFromCart/V1/CreateOrderFromCartCommandHandlerV1.cs
@@ -179,7 +179,7 @@ internal sealed class
             }
 
             // **CRITICAL: Commit the transaction to save to database**
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Order {OrderId} created successfully from cart {CartId}", order.Id, cart.Id);
 

--- a/Shopilent.Application/Features/Sales/Commands/MarkOrderAsDelivered/V1/MarkOrderAsDeliveredCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/MarkOrderAsDelivered/V1/MarkOrderAsDeliveredCommandHandlerV1.cs
@@ -49,7 +49,7 @@ internal sealed class MarkOrderAsDeliveredCommandHandlerV1 : ICommandHandler<Mar
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Order {OrderId} marked as delivered successfully by user {UserId}", 
                 request.OrderId, _currentUserContext.UserId);

--- a/Shopilent.Application/Features/Sales/Commands/MarkOrderAsShipped/V1/MarkOrderAsShippedCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/MarkOrderAsShipped/V1/MarkOrderAsShippedCommandHandlerV1.cs
@@ -53,7 +53,7 @@ internal sealed class MarkOrderAsShippedCommandHandlerV1 : ICommandHandler<MarkO
 
             await _unitOfWork.OrderWriter.UpdateAsync(order, cancellationToken);
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(
                 "Order marked as shipped successfully. OrderId: {OrderId}, TrackingNumber: {TrackingNumber}",

--- a/Shopilent.Application/Features/Sales/Commands/RemoveItemFromCart/V1/RemoveItemFromCartCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/RemoveItemFromCart/V1/RemoveItemFromCartCommandHandlerV1.cs
@@ -52,7 +52,7 @@ internal sealed class RemoveItemFromCartCommandHandlerV1 : ICommandHandler<Remov
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Item {ItemId} successfully removed from cart {CartId} for user {UserId}", 
                 request.ItemId, cart.Id, cart.UserId ?? Guid.Empty);

--- a/Shopilent.Application/Features/Sales/Commands/UpdateCartItemQuantity/V1/UpdateCartItemQuantityCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/UpdateCartItemQuantity/V1/UpdateCartItemQuantityCommandHandlerV1.cs
@@ -53,7 +53,7 @@ internal sealed class UpdateCartItemQuantityCommandHandlerV1 : ICommandHandler<U
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Cart item quantity updated successfully. CartId: {CartId}, ItemId: {ItemId}, Quantity: {Quantity}, UserId: {UserId}", 
                 cart.Id, request.CartItemId, request.Quantity, cart.UserId);

--- a/Shopilent.Application/Features/Sales/Commands/UpdateOrderStatus/V1/UpdateOrderStatusCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Sales/Commands/UpdateOrderStatus/V1/UpdateOrderStatusCommandHandlerV1.cs
@@ -69,7 +69,7 @@ internal sealed class UpdateOrderStatusCommandHandlerV1 : ICommandHandler<Update
             }
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Order status updated successfully. Order ID: {OrderId}, New Status: {Status}", 
                 order.Id, request.Status);

--- a/Shopilent.Application/Features/Shipping/Commands/CreateAddress/V1/CreateAddressCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Shipping/Commands/CreateAddress/V1/CreateAddressCommandHandlerV1.cs
@@ -116,7 +116,7 @@ internal sealed class CreateAddressCommandHandlerV1 : ICommandHandler<CreateAddr
             // Save the address
             var savedAddress = await _unitOfWork.AddressWriter.AddAsync(addressResult.Value, cancellationToken);
 
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
 
             _logger.LogInformation("Address created successfully with ID: {AddressId} for user: {UserId}",

--- a/Shopilent.Application/Features/Shipping/Commands/DeleteAddress/V1/DeleteAddressCommandHandlerV1.cs
+++ b/Shopilent.Application/Features/Shipping/Commands/DeleteAddress/V1/DeleteAddressCommandHandlerV1.cs
@@ -61,7 +61,7 @@ internal sealed class DeleteAddressCommandHandlerV1 : ICommandHandler<DeleteAddr
             await _unitOfWork.AddressWriter.DeleteAsync(address, cancellationToken);
 
             // Save changes
-            await _unitOfWork.SaveEntitiesAsync(cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Address deleted successfully with ID: {AddressId} for user: {UserId}",
                 address.Id, _currentUserContext.UserId);

--- a/Shopilent.Domain/Identity/Repositories/Read/IUserReadRepository.cs
+++ b/Shopilent.Domain/Identity/Repositories/Read/IUserReadRepository.cs
@@ -7,10 +7,6 @@ public interface IUserReadRepository : IAggregateReadRepository<UserDto>
 {
     Task<UserDetailDto> GetDetailByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<UserDto> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
-
-    Task<User> GetUserByCredentialsAsync(string email, string passwordHash,
-        CancellationToken cancellationToken = default);
-
     Task<UserDto> GetByRefreshTokenAsync(string token, CancellationToken cancellationToken = default);
     Task<UserDto> GetByEmailVerificationTokenAsync(string token, CancellationToken cancellationToken = default);
     Task<UserDto> GetByPasswordResetTokenAsync(string token, CancellationToken cancellationToken = default);

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
@@ -108,7 +108,7 @@ public class AuditSaveChangesInterceptor : SaveChangesInterceptor
 
                 case EntityState.Modified:
                     entry.Entity.IncrementVersion();
-                   
+
                     var oldValues = GetOriginalValues(entry);
                     var currentValues = GetEntityValues(entry);
                     CreateAuditLog(context, entityType, entry.Entity.Id, AuditAction.Update, user,

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Repositories/Catalog/Write/CategoryWriteRepository.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Repositories/Catalog/Write/CategoryWriteRepository.cs
@@ -27,7 +27,7 @@ public class CategoryWriteRepository : AggregateWriteRepositoryBase<Category>, I
         return await DbContext.Categories
             .Include(c => c.Children)
             .Include(c => c.ProductCategories)
-            .FirstOrDefaultAsync(c => EF.Property<string>(c, "Slug.Value") == slug, cancellationToken);
+            .FirstOrDefaultAsync(c => c.Slug.Value == slug, cancellationToken);
     }
 
     public async Task<bool> SlugExistsAsync(string slug, Guid? excludeId = null,

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/Repositories/Identity/Read/UserReadRepository.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/Repositories/Identity/Read/UserReadRepository.cs
@@ -19,7 +19,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public override async Task<UserDto> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -41,7 +41,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public override async Task<IReadOnlyList<UserDto>> ListAllAsync(CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -63,7 +63,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public async Task<UserDetailDto> GetDetailByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         const string userSql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -90,7 +90,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
         {
             // Load addresses
             const string addressesSql = @"
-                SELECT 
+                SELECT
                     id AS Id,
                     user_id AS UserId,
                     address_line1 AS AddressLine1,
@@ -112,7 +112,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
 
             // Load refresh tokens
             const string tokensSql = @"
-                SELECT 
+                SELECT
                     id AS Id,
                     user_id AS UserId,
                     token AS Token,
@@ -137,7 +137,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public async Task<UserDto> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -156,22 +156,10 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
         return await Connection.QueryFirstOrDefaultAsync<UserDto>(sql, new { Email = email });
     }
 
-    public async Task<User> GetUserByCredentialsAsync(string email, string passwordHash,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = @"
-            SELECT * FROM users
-            WHERE email = @Email
-            AND password_hash = @PasswordHash
-            AND is_active = true";
-
-        return await Connection.QueryFirstOrDefaultAsync<User>(sql, new { Email = email, PasswordHash = passwordHash });
-    }
-
     public async Task<UserDto> GetByRefreshTokenAsync(string token, CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 u.id AS Id,
                 u.email AS Email,
                 u.first_name AS FirstName,
@@ -197,7 +185,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
         CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -220,7 +208,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public async Task<UserDto> GetByPasswordResetTokenAsync(string token, CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -268,7 +256,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
     public async Task<IReadOnlyList<UserDto>> GetByRoleAsync(string role, CancellationToken cancellationToken = default)
     {
         const string sql = @"
-            SELECT 
+            SELECT
                 id AS Id,
                 email AS Email,
                 first_name AS FirstName,
@@ -298,7 +286,7 @@ public class UserReadRepository : AggregateReadRepositoryBase<User, UserDto>, IU
         var idArray = ids.ToArray();
 
         const string sql = @"
-        SELECT 
+        SELECT
             id AS Id,
             email AS Email,
             first_name AS FirstName,

--- a/Shopilent.Infrastructure.Persistence.PostgreSQL/UnitOfWork.cs
+++ b/Shopilent.Infrastructure.Persistence.PostgreSQL/UnitOfWork.cs
@@ -129,13 +129,6 @@ public class UnitOfWork : IUnitOfWork
         return await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task<bool> SaveEntitiesAsync(CancellationToken cancellationToken = default)
-    {
-        // Handle domain events if needed before saving
-        await _dbContext.SaveChangesAsync(cancellationToken);
-        return true;
-    }
-
     public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
         _transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);


### PR DESCRIPTION
- Replaced deprecated `SaveEntitiesAsync` with `SaveChangesAsync` for saving changes in repositories and handlers.
- Removed obsolete `SaveEntitiesAsync` implementation from `IUnitOfWork` and `UnitOfWork`.
- Updated associated unit tests to verify `SaveChangesAsync` usage.