### PR TITLE
Add unit tests for identity command handlers

### DIFF
--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/ChangeUserRoleCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/ChangeUserRoleCommandTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Identity.Commands.ChangeUserRole.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Enums;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class ChangeUserRoleCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public ChangeUserRoleCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ChangeUserRoleCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<ChangeUserRoleCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<ChangeUserRoleCommandV1>, ChangeUserRoleCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task ChangeUserRole_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = targetUserId,
+            NewRole = UserRole.Manager
+        };
+        
+        var targetUser = new UserBuilder()
+            .WithId(targetUserId)
+            .WithRole(UserRole.Customer)
+            .Build();
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(targetUserId, CancellationToken))
+            .ReturnsAsync(targetUser);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the user's role was changed
+        targetUser.Role.Should().Be(UserRole.Manager);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task ChangeUserRole_WithNonExistentUser_ReturnsErrorResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = targetUserId,
+            NewRole = UserRole.Manager
+        };
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock user not found
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(targetUserId, CancellationToken))
+            .ReturnsAsync((User)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(targetUserId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    
+    [Fact]
+    public async Task ChangeUserRole_PromoteToAdmin_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = targetUserId,
+            NewRole = UserRole.Admin
+        };
+        
+        var targetUser = new UserBuilder()
+            .WithId(targetUserId)
+            .WithRole(UserRole.Manager)
+            .Build();
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(targetUserId, CancellationToken))
+            .ReturnsAsync(targetUser);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the user's role was changed to Admin
+        targetUser.Role.Should().Be(UserRole.Admin);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task ChangeUserRole_DemoteFromAdmin_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = targetUserId,
+            NewRole = UserRole.Customer
+        };
+        
+        var targetUser = new UserBuilder()
+            .WithId(targetUserId)
+            .WithRole(UserRole.Admin)
+            .Build();
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(targetUserId, CancellationToken))
+            .ReturnsAsync(targetUser);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the user's role was changed to Customer
+        targetUser.Role.Should().Be(UserRole.Customer);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task ChangeUserRole_WithSameRole_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = targetUserId,
+            NewRole = UserRole.Manager
+        };
+        
+        var targetUser = new UserBuilder()
+            .WithId(targetUserId)
+            .WithRole(UserRole.Manager) // Already has the target role
+            .Build();
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(targetUserId, CancellationToken))
+            .ReturnsAsync(targetUser);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the user's role remains the same
+        targetUser.Role.Should().Be(UserRole.Manager);
+        
+        // Verify save was NOT called since no change was made (handler optimizes for this case)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task ChangeUserRole_ChangingSelfRole_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var currentUserId = Guid.NewGuid();
+        
+        var command = new ChangeUserRoleCommandV1
+        {
+            UserId = currentUserId, // Changing own role
+            NewRole = UserRole.Customer
+        };
+        
+        var currentUser = new UserBuilder()
+            .WithId(currentUserId)
+            .WithRole(UserRole.Admin)
+            .Build();
+        
+        // Setup authenticated admin user
+        Fixture.SetAuthenticatedUser(currentUserId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(currentUserId, CancellationToken))
+            .ReturnsAsync(currentUser);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the user's own role was changed
+        currentUser.Role.Should().Be(UserRole.Customer);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserCommandTests.cs
@@ -1,0 +1,364 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Commands.UpdateUser.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class UpdateUserCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public UpdateUserCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateUserCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            MiddleName = "Michael",
+            Phone = "+1234567890",
+            IpAddress = "127.0.0.1",
+            UserAgent = "Test User Agent"
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.User.Should().NotBeNull();
+        result.Value.User.FullName.FirstName.Should().Be("John");
+        result.Value.User.FullName.LastName.Should().Be("Doe");
+        result.Value.User.FullName.MiddleName.Should().Be("Michael");
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((User)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidFirstName_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "", // Invalid empty first name
+            LastName = "Doe"
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.FirstNameRequired");
+        result.Error.Message.Should().Contain("First name cannot be empty");
+
+        // Verify that update was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLastName_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "" // Invalid empty last name
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.LastNameRequired");
+        result.Error.Message.Should().Contain("Last name cannot be empty");
+
+        // Verify that update was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidPhoneNumber_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "invalid-phone" // Invalid phone format
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.InvalidPhoneFormat");
+
+        // Verify that update was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithoutPhoneAndMiddleName_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+            // Phone and MiddleName are null/empty
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.User.Should().NotBeNull();
+        result.Value.User.FullName.FirstName.Should().Be("John");
+        result.Value.User.FullName.LastName.Should().Be("Doe");
+        result.Value.User.FullName.MiddleName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithEmptyPhoneString_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "" // Empty phone should be treated as null
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.User.Should().NotBeNull();
+        result.Value.User.FullName.FirstName.Should().Be("John");
+        result.Value.User.FullName.LastName.Should().Be("Doe");
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("UpdateUser.Failed");
+        result.Error.Message.Should().Contain("Failed to update user");
+    }
+
+    [Theory]
+    [InlineData("John", "Doe", "Michael", "+1234567890")]
+    [InlineData("Jane", "Smith", null, "+9876543210")]
+    [InlineData("Bob", "Johnson", "", null)]
+    [InlineData("Alice", "Williams", "Marie", "")]
+    public async Task Handle_ValidVariousInputCombinations_ReturnsSuccess(
+        string firstName, string lastName, string middleName, string phone)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserCommandV1
+        {
+            UserId = userId,
+            FirstName = firstName,
+            LastName = lastName,
+            MiddleName = middleName,
+            Phone = phone
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var existingUser = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingUser);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.UpdateAsync(It.IsAny<User>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.User.Should().NotBeNull();
+        result.Value.User.FullName.FirstName.Should().Be(firstName);
+        result.Value.User.FullName.LastName.Should().Be(lastName);
+        
+        if (string.IsNullOrEmpty(middleName))
+        {
+            // FullName.Create stores empty strings as-is, not as null
+            result.Value.User.FullName.MiddleName.Should().Be(middleName);
+        }
+        else
+        {
+            result.Value.User.FullName.MiddleName.Should().Be(middleName);
+        }
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserProfileCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserProfileCommandTests.cs
@@ -1,0 +1,463 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Commands.UpdateUserProfile.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class UpdateUserProfileCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public UpdateUserProfileCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateUserProfileCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+        var userId = user.Id; // Use the actual user's ID
+        var currentUserId = Guid.NewGuid();
+        
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            MiddleName = "Michael",
+            Phone = "+1234567890"
+        };
+
+        Fixture.SetAuthenticatedUser(currentUserId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(userId);
+        result.Value.FirstName.Should().Be("John");
+        result.Value.LastName.Should().Be("Doe");
+        result.Value.MiddleName.Should().Be("Michael");
+        result.Value.Phone.Should().Be("+1234567890");
+        result.Value.UpdatedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+
+        // Verify user was updated
+        user.FullName.FirstName.Should().Be("John");
+        user.FullName.LastName.Should().Be("Doe");
+        user.FullName.MiddleName.Should().Be("Michael");
+        user.Phone.Value.Should().Be("+1234567890");
+        user.ModifiedBy.Should().Be(currentUserId);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((User)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidFirstName_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "", // Invalid empty first name
+            LastName = "Doe"
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.FirstNameRequired");
+        result.Error.Message.Should().Contain("First name cannot be empty");
+
+        // Verify that save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidLastName_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "" // Invalid empty last name
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.LastNameRequired");
+        result.Error.Message.Should().Contain("Last name cannot be empty");
+
+        // Verify that save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidPhoneNumber_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "invalid-phone" // Invalid phone format
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.InvalidPhoneFormat");
+
+        // Verify that save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithoutPhoneAndMiddleName_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+            // Phone and MiddleName are null
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FirstName.Should().Be("John");
+        result.Value.LastName.Should().Be("Doe");
+        result.Value.MiddleName.Should().BeNull();
+        result.Value.Phone.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithEmptyPhoneString_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Phone = "" // Empty phone should be treated as null
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FirstName.Should().Be("John");
+        result.Value.LastName.Should().Be("Doe");
+        result.Value.Phone.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NoCurrentUserContext_StillWorksButNoAuditInfo()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        // Don't set authenticated user (no current user context)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FirstName.Should().Be("John");
+        result.Value.LastName.Should().Be("Doe");
+
+        // ModifiedBy should not be set when no current user context
+        user.ModifiedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.UpdateProfileFailed");
+        result.Error.Message.Should().Contain("Failed to update user profile");
+    }
+
+    [Theory]
+    [InlineData("John", "Doe", "Michael", "+1234567890")]
+    [InlineData("Jane", "Smith", null, "+9876543210")]
+    [InlineData("Bob", "Johnson", "", null)]
+    [InlineData("Alice", "Williams", "Marie", "")]
+    public async Task Handle_ValidVariousInputCombinations_ReturnsSuccess(
+        string firstName, string lastName, string middleName, string phone)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = firstName,
+            LastName = lastName,
+            MiddleName = middleName,
+            Phone = phone
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.FirstName.Should().Be(firstName);
+        result.Value.LastName.Should().Be(lastName);
+        
+        if (string.IsNullOrEmpty(middleName))
+        {
+            // FullName.Create stores empty strings as-is, not as null
+            result.Value.MiddleName.Should().Be(middleName);
+        }
+        else
+        {
+            result.Value.MiddleName.Should().Be(middleName);
+        }
+
+        if (string.IsNullOrEmpty(phone))
+        {
+            result.Value.Phone.Should().BeNull();
+        }
+        else
+        {
+            result.Value.Phone.Should().Be(phone);
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ResponseTimestamp_IsReasonablyCurrent()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserProfileCommandV1
+        {
+            UserId = userId,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var originalFullName = FullName.Create("Original", "Name").Value;
+        var user = User.Create(email, "hashedPassword", originalFullName).Value;
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        var beforeExecution = DateTime.UtcNow;
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        var afterExecution = DateTime.UtcNow;
+        
+        result.IsSuccess.Should().BeTrue();
+        result.Value.UpdatedAt.Should().BeOnOrAfter(beforeExecution);
+        result.Value.UpdatedAt.Should().BeOnOrBefore(afterExecution);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Commands/UpdateUserStatusCommandTests.cs
@@ -1,0 +1,403 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Identity;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Commands.UpdateUserStatus.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Identity.ValueObjects;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Commands;
+
+public class UpdateUserStatusCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public UpdateUserStatusCommandTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateUserStatusCommandHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ActivateUser_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        user.Deactivate(); // Deactivate first to test activation
+
+        var currentUserId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(currentUserId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeTrue();
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DeactivateUser_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = false
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        // User is active by default
+
+        var currentUserId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(currentUserId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeFalse();
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((User)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UserTriesToDeactivateSelf_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = false
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        // Set the current user context to the same user being deactivated
+        Fixture.SetAuthenticatedUser(userId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.CannotDeactivateSelf.Code);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UserCanActivateSelf_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        user.Deactivate(); // Deactivate first
+
+        // Set the current user context to the same user being activated
+        Fixture.SetAuthenticatedUser(userId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeTrue();
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoCurrentUserContext_StillWorksForActivation()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        user.Deactivate();
+
+        // Don't set authenticated user (no current user context)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NoCurrentUserContext_StillWorksForDeactivation()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = false
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+
+        // Don't set authenticated user (no current user context)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.UpdateStatusFailed");
+        result.Error.Message.Should().Contain("Failed to update user status");
+    }
+
+    [Fact]
+    public async Task Handle_WhenSaveEntitiesFails_ReturnsSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = true
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        user.Deactivate();
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // SaveChangesAsync returns false, but this is still considered success
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(0);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Handle_WithAuditInfoWhenUserContextAvailable_SetsAuditInfo(bool isActive)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var currentUserId = Guid.NewGuid();
+        var command = new UpdateUserStatusCommandV1
+        {
+            Id = userId,
+            IsActive = isActive
+        };
+
+        var email = Email.Create("test@example.com").Value;
+        var fullName = FullName.Create("John", "Doe").Value;
+        var user = User.Create(email, "hashedPassword", fullName).Value;
+        
+        if (isActive)
+            user.Deactivate(); // Start deactivated to test activation
+        // else user is active by default for deactivation test
+
+        Fixture.SetAuthenticatedUser(currentUserId);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserWriter.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().Be(isActive);
+        user.ModifiedBy.Should().Be(currentUserId);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Queries/GetCurrentUserProfileQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Queries/GetCurrentUserProfileQueryHandlerTests.cs
@@ -1,0 +1,365 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Queries.GetCurrentUserProfile.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.DTOs;
+using Shopilent.Domain.Identity.Enums;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Shipping.DTOs;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Queries;
+
+public class GetCurrentUserProfileQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public GetCurrentUserProfileQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetCurrentUserProfileQueryHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidUserId_ReturnsUserProfile()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            MiddleName = "Michael",
+            Phone = "+1234567890",
+            Role = UserRole.Customer,
+            IsActive = true,
+            EmailVerified = true,
+            LastLogin = DateTime.UtcNow.AddDays(-1),
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0,
+            LastFailedAttempt = null,
+            CreatedBy = null,
+            ModifiedBy = null,
+            LastModified = null
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(expectedUserDetail.Id);
+        result.Value.Email.Should().Be(expectedUserDetail.Email);
+        result.Value.FirstName.Should().Be(expectedUserDetail.FirstName);
+        result.Value.LastName.Should().Be(expectedUserDetail.LastName);
+        result.Value.MiddleName.Should().Be(expectedUserDetail.MiddleName);
+        result.Value.Phone.Should().Be(expectedUserDetail.Phone);
+        result.Value.Role.Should().Be(expectedUserDetail.Role);
+        result.Value.IsActive.Should().Be(expectedUserDetail.IsActive);
+        result.Value.EmailVerified.Should().Be(expectedUserDetail.EmailVerified);
+
+        // Verify repository interaction
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((UserDetailDto)null);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+
+        // Verify repository interaction
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserWithAddressesAndTokens_ReturnsCompleteProfile()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        var addresses = new List<AddressDto>
+        {
+            new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                AddressLine1 = "123 Main St",
+                AddressLine2 = "Apt 4B",
+                City = "New York",
+                State = "NY",
+                PostalCode = "10001",
+                Country = "US",
+                IsDefault = true
+            }
+        };
+
+        var refreshTokens = new List<RefreshTokenDto>
+        {
+            new RefreshTokenDto
+            {
+                Id = Guid.NewGuid(),
+                Token = "refresh-token-1",
+                ExpiresAt = DateTime.UtcNow.AddDays(30),
+                CreatedAt = DateTime.UtcNow.AddDays(-5),
+                IsRevoked = false
+            }
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            Role = UserRole.Admin,
+            IsActive = true,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = addresses.AsReadOnly(),
+            RefreshTokens = refreshTokens.AsReadOnly(),
+            FailedLoginAttempts = 2,
+            LastFailedAttempt = DateTime.UtcNow.AddDays(-2),
+            CreatedBy = Guid.NewGuid(),
+            ModifiedBy = Guid.NewGuid(),
+            LastModified = DateTime.UtcNow.AddDays(-1)
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Addresses.Should().HaveCount(1);
+        result.Value.RefreshTokens.Should().HaveCount(1);
+        result.Value.FailedLoginAttempts.Should().Be(2);
+        result.Value.LastFailedAttempt.Should().NotBeNull();
+        result.Value.CreatedBy.Should().NotBeNull();
+        result.Value.ModifiedBy.Should().NotBeNull();
+        result.Value.LastModified.Should().NotBeNull();
+
+        // Verify address details
+        var address = result.Value.Addresses.First();
+        address.AddressLine1.Should().Be("123 Main St");
+        address.AddressLine2.Should().Be("Apt 4B");
+        address.City.Should().Be("New York");
+        address.IsDefault.Should().BeTrue();
+
+        // Verify refresh token details
+        var refreshToken = result.Value.RefreshTokens.First();
+        refreshToken.Token.Should().Be("refresh-token-1");
+        refreshToken.IsRevoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("UserProfile.GetFailed");
+        result.Error.Message.Should().Contain("Failed to retrieve user profile");
+    }
+
+    [Fact]
+    public async Task Handle_QueryImplementsCachedQuery()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        // Assert - Verify the query implements ICachedQuery
+        query.CacheKey.Should().Be($"user-profile-{userId}");
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Theory]
+    [InlineData(UserRole.Customer)]
+    [InlineData(UserRole.Admin)]
+    [InlineData(UserRole.Manager)]
+    public async Task Handle_DifferentUserRoles_ReturnsCorrectProfile(UserRole userRole)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            Role = userRole,
+            IsActive = true,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Role.Should().Be(userRole);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Handle_DifferentActiveStates_ReturnsCorrectProfile(bool isActive)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            Role = UserRole.Customer,
+            IsActive = isActive,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsActive.Should().Be(isActive);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyAddressesAndTokensLists_ReturnsProfileWithEmptyLists()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetCurrentUserProfileQueryV1
+        {
+            UserId = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            Role = UserRole.Customer,
+            IsActive = true,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(), // Empty list
+            RefreshTokens = new List<RefreshTokenDto>(), // Empty list
+            FailedLoginAttempts = 0
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Addresses.Should().BeEmpty();
+        result.Value.RefreshTokens.Should().BeEmpty();
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Queries/GetUserQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Queries/GetUserQueryHandlerTests.cs
@@ -1,0 +1,463 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Queries.GetUser.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.DTOs;
+using Shopilent.Domain.Identity.Enums;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Shipping.DTOs;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Queries;
+
+public class GetUserQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public GetUserQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetUserQueryHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidUserId_ReturnsUserDetail()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "john.doe@example.com",
+            FirstName = "John",
+            LastName = "Doe",
+            MiddleName = "Michael",
+            Phone = "+1234567890",
+            Role = UserRole.Customer,
+            IsActive = true,
+            EmailVerified = true,
+            LastLogin = DateTime.UtcNow.AddDays(-2),
+            CreatedAt = DateTime.UtcNow.AddDays(-60),
+            UpdatedAt = DateTime.UtcNow.AddDays(-10),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0,
+            LastFailedAttempt = null,
+            CreatedBy = null,
+            ModifiedBy = null,
+            LastModified = null
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(expectedUserDetail.Id);
+        result.Value.Email.Should().Be(expectedUserDetail.Email);
+        result.Value.FirstName.Should().Be(expectedUserDetail.FirstName);
+        result.Value.LastName.Should().Be(expectedUserDetail.LastName);
+        result.Value.MiddleName.Should().Be(expectedUserDetail.MiddleName);
+        result.Value.Phone.Should().Be(expectedUserDetail.Phone);
+        result.Value.Role.Should().Be(expectedUserDetail.Role);
+        result.Value.IsActive.Should().Be(expectedUserDetail.IsActive);
+        result.Value.EmailVerified.Should().Be(expectedUserDetail.EmailVerified);
+
+        // Verify repository interaction
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((UserDetailDto)null);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+
+        // Verify repository interaction
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AdminUserWithCompleteProfile_ReturnsCompleteDetails()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var creatorId = Guid.NewGuid();
+        var modifierId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var addresses = new List<AddressDto>
+        {
+            new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                AddressLine1 = "456 Admin Ave",
+                AddressLine2 = "Suite 789",
+                City = "Washington",
+                State = "DC",
+                PostalCode = "20001",
+                Country = "US",
+                IsDefault = true
+            },
+            new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                AddressLine1 = "789 Secondary St",
+                City = "Arlington",
+                State = "VA",
+                PostalCode = "22201",
+                Country = "US",
+                IsDefault = false
+            }
+        };
+
+        var refreshTokens = new List<RefreshTokenDto>
+        {
+            new RefreshTokenDto
+            {
+                Id = Guid.NewGuid(),
+                Token = "active-refresh-token",
+                ExpiresAt = DateTime.UtcNow.AddDays(30),
+                CreatedAt = DateTime.UtcNow.AddDays(-1),
+                IsRevoked = false
+            },
+            new RefreshTokenDto
+            {
+                Id = Guid.NewGuid(),
+                Token = "revoked-refresh-token",
+                ExpiresAt = DateTime.UtcNow.AddDays(15),
+                CreatedAt = DateTime.UtcNow.AddDays(-15),
+                IsRevoked = true
+            }
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "admin@company.com",
+            FirstName = "John",
+            LastName = "Doe",
+            MiddleName = "Michael",
+            Phone = "+1987654321",
+            Role = UserRole.Admin,
+            IsActive = true,
+            EmailVerified = true,
+            LastLogin = DateTime.UtcNow.AddHours(-2),
+            CreatedAt = DateTime.UtcNow.AddDays(-120),
+            UpdatedAt = DateTime.UtcNow.AddDays(-3),
+            Addresses = addresses.AsReadOnly(),
+            RefreshTokens = refreshTokens.AsReadOnly(),
+            FailedLoginAttempts = 1,
+            LastFailedAttempt = DateTime.UtcNow.AddDays(-7),
+            CreatedBy = creatorId,
+            ModifiedBy = modifierId,
+            LastModified = DateTime.UtcNow.AddDays(-3)
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Role.Should().Be(UserRole.Admin);
+        result.Value.Addresses.Should().HaveCount(2);
+        result.Value.RefreshTokens.Should().HaveCount(2);
+        result.Value.FailedLoginAttempts.Should().Be(1);
+        result.Value.LastFailedAttempt.Should().NotBeNull();
+        result.Value.CreatedBy.Should().Be(creatorId);
+        result.Value.ModifiedBy.Should().Be(modifierId);
+        result.Value.LastModified.Should().NotBeNull();
+
+        // Verify address details
+        var defaultAddress = result.Value.Addresses.First(a => a.IsDefault);
+        defaultAddress.AddressLine1.Should().Be("456 Admin Ave");
+        defaultAddress.AddressLine2.Should().Be("Suite 789");
+        defaultAddress.City.Should().Be("Washington");
+
+        var secondaryAddress = result.Value.Addresses.First(a => !a.IsDefault);
+        secondaryAddress.AddressLine1.Should().Be("789 Secondary St");
+        secondaryAddress.City.Should().Be("Arlington");
+
+        // Verify refresh token details
+        var activeToken = result.Value.RefreshTokens.First(t => !t.IsRevoked);
+        activeToken.Token.Should().Be("active-refresh-token");
+        activeToken.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+
+        var revokedToken = result.Value.RefreshTokens.First(t => t.IsRevoked);
+        revokedToken.Token.Should().Be("revoked-refresh-token");
+        revokedToken.IsRevoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_InactiveUserWithFailedLogins_ReturnsCorrectDetails()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "inactive.user@example.com",
+            FirstName = "Inactive",
+            LastName = "User",
+            Role = UserRole.Customer,
+            IsActive = false,
+            EmailVerified = false,
+            LastLogin = DateTime.UtcNow.AddDays(-30),
+            CreatedAt = DateTime.UtcNow.AddDays(-90),
+            UpdatedAt = DateTime.UtcNow.AddDays(-20),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 5,
+            LastFailedAttempt = DateTime.UtcNow.AddHours(-6),
+            CreatedBy = null,
+            ModifiedBy = null,
+            LastModified = null
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.IsActive.Should().BeFalse();
+        result.Value.EmailVerified.Should().BeFalse();
+        result.Value.FailedLoginAttempts.Should().Be(5);
+        result.Value.LastFailedAttempt.Should().NotBeNull();
+        result.Value.Addresses.Should().BeEmpty();
+        result.Value.RefreshTokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection error"));
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("User.GetDetailFailed");
+        result.Error.Message.Should().Contain("Failed to retrieve user detail");
+        result.Error.Message.Should().Contain("Database connection error");
+    }
+
+    [Fact]
+    public async Task Handle_QueryImplementsCachedQuery()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        // Assert - Verify the query implements ICachedQuery
+        query.CacheKey.Should().Be($"user-detail-{userId}");
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Theory]
+    [InlineData(UserRole.Customer)]
+    [InlineData(UserRole.Admin)]
+    [InlineData(UserRole.Manager)]
+    public async Task Handle_DifferentUserRoles_ReturnsCorrectRole(UserRole userRole)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "Test",
+            LastName = "User",
+            Role = userRole,
+            IsActive = true,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Role.Should().Be(userRole);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(10)]
+    public async Task Handle_DifferentFailedLoginAttempts_ReturnsCorrectCount(int failedAttempts)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var lastFailedAttempt = failedAttempts > 0 ? DateTime.UtcNow.AddHours(-2) : (DateTime?)null;
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "test@example.com",
+            FirstName = "Test",
+            LastName = "User",
+            Role = UserRole.Customer,
+            IsActive = true,
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = failedAttempts,
+            LastFailedAttempt = lastFailedAttempt
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.FailedLoginAttempts.Should().Be(failedAttempts);
+        result.Value.LastFailedAttempt.Should().Be(lastFailedAttempt);
+    }
+
+    [Fact]
+    public async Task Handle_UserWithNullOptionalFields_ReturnsUserWithNullFields()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var query = new GetUserQueryV1
+        {
+            Id = userId
+        };
+
+        var expectedUserDetail = new UserDetailDto
+        {
+            Id = userId,
+            Email = "minimal@example.com",
+            FirstName = "Minimal",
+            LastName = "User",
+            MiddleName = null, // Null middle name
+            Phone = null, // Null phone
+            Role = UserRole.Customer,
+            IsActive = true,
+            EmailVerified = true,
+            LastLogin = null, // Never logged in
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Addresses = new List<AddressDto>(),
+            RefreshTokens = new List<RefreshTokenDto>(),
+            FailedLoginAttempts = 0,
+            LastFailedAttempt = null,
+            CreatedBy = null,
+            ModifiedBy = null,
+            LastModified = null
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDetailByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(expectedUserDetail);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.MiddleName.Should().BeNull();
+        result.Value.Phone.Should().BeNull();
+        result.Value.LastLogin.Should().BeNull();
+        result.Value.LastFailedAttempt.Should().BeNull();
+        result.Value.CreatedBy.Should().BeNull();
+        result.Value.ModifiedBy.Should().BeNull();
+        result.Value.LastModified.Should().BeNull();
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Identity/Queries/GetUsersDatatableQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Identity/Queries/GetUsersDatatableQueryHandlerTests.cs
@@ -1,0 +1,519 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Persistence;
+using Shopilent.Application.Features.Identity.Queries.GetUsersDatatable.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Identity.DTOs;
+using Shopilent.Domain.Identity.Enums;
+using Shopilent.Domain.Shipping.DTOs;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Identity.Queries;
+
+public class GetUsersDatatableQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public GetUsersDatatableQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetUsersDatatableQueryHandlerV1>());
+
+        services.AddMediatRWithValidation();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsDatatableResult()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "john.doe@example.com",
+                FirstName = "John",
+                LastName = "Doe",
+                Phone = "+1234567890",
+                Role = UserRole.Customer,
+                IsActive = true,
+                EmailVerified = true,
+                LastLogin = DateTime.UtcNow.AddDays(-1),
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            },
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "jane.smith@example.com",
+                FirstName = "Jane",
+                LastName = "Smith",
+                Phone = "+9876543210",
+                Role = UserRole.Admin,
+                IsActive = true,
+                EmailVerified = true,
+                LastLogin = DateTime.UtcNow.AddHours(-2),
+                CreatedAt = DateTime.UtcNow.AddDays(-60),
+                UpdatedAt = DateTime.UtcNow.AddDays(-10)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 100, 2, users);
+
+        var addresses1 = new List<AddressDto>
+        {
+            new AddressDto { Id = Guid.NewGuid() },
+            new AddressDto { Id = Guid.NewGuid() }
+        };
+
+        var addresses2 = new List<AddressDto>
+        {
+            new AddressDto { Id = Guid.NewGuid() }
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ReturnsAsync(addresses1);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[1].Id, CancellationToken))
+            .ReturnsAsync(addresses2);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(100);
+        result.Value.RecordsFiltered.Should().Be(2);
+        result.Value.Data.Should().HaveCount(2);
+
+        // Verify first user
+        var firstUser = result.Value.Data.First();
+        firstUser.Email.Should().Be("john.doe@example.com");
+        firstUser.FirstName.Should().Be("John");
+        firstUser.LastName.Should().Be("Doe");
+        firstUser.FullName.Should().Be("John Doe");
+        firstUser.Role.Should().Be(UserRole.Customer);
+        firstUser.RoleName.Should().Be("Customer");
+        firstUser.IsActive.Should().BeTrue();
+        firstUser.IsEmailVerified.Should().BeTrue();
+        firstUser.AddressCount.Should().Be(2);
+
+        // Verify second user
+        var secondUser = result.Value.Data.Last();
+        secondUser.Email.Should().Be("jane.smith@example.com");
+        secondUser.FirstName.Should().Be("Jane");
+        secondUser.LastName.Should().Be("Smith");
+        secondUser.FullName.Should().Be("Jane Smith");
+        secondUser.Role.Should().Be(UserRole.Admin);
+        secondUser.RoleName.Should().Be("Admin");
+        secondUser.IsActive.Should().BeTrue();
+        secondUser.IsEmailVerified.Should().BeTrue();
+        secondUser.AddressCount.Should().Be(1);
+
+        // Verify repository interactions
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken),
+            Times.Once);
+
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.AddressReader.GetByUserIdAsync(It.IsAny<Guid>(), CancellationToken),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_UserWithNoAddresses_ReturnsZeroAddressCount()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "no.address@example.com",
+                FirstName = "No",
+                LastName = "Address",
+                Role = UserRole.Customer,
+                IsActive = true,
+                EmailVerified = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 1, 1, users);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ReturnsAsync((List<AddressDto>)null); // No addresses
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Data.Should().HaveCount(1);
+        result.Value.Data.First().AddressCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyResults_ReturnsEmptyDataTable()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 2,
+            Start = 10,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var emptyUsers = new List<UserDto>();
+        var datatableResult = new DataTableResult<UserDto>(2, 5, 0, emptyUsers);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Draw.Should().Be(2);
+        result.Value.RecordsTotal.Should().Be(5);
+        result.Value.RecordsFiltered.Should().Be(0);
+        result.Value.Data.Should().BeEmpty();
+
+        // Verify no address queries were made
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.AddressReader.GetByUserIdAsync(It.IsAny<Guid>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(UserRole.Customer, "Customer")]
+    [InlineData(UserRole.Admin, "Admin")]
+    [InlineData(UserRole.Manager, "Manager")]
+    public async Task Handle_DifferentUserRoles_ReturnsCorrectRoleNames(UserRole role, string expectedRoleName)
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "test@example.com",
+                FirstName = "Test",
+                LastName = "User",
+                Role = role,
+                IsActive = true,
+                EmailVerified = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 1, 1, users);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ReturnsAsync(new List<AddressDto>());
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Data.First().RoleName.Should().Be(expectedRoleName);
+    }
+
+    [Fact]
+    public async Task Handle_UserWithMiddleNameInFullName_TrimsCorrectly()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "test@example.com",
+                FirstName = "John",
+                LastName = "Doe",
+                Role = UserRole.Customer,
+                IsActive = true,
+                EmailVerified = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 1, 1, users);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ReturnsAsync(new List<AddressDto>());
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Data.First().FullName.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Users.GetDataTableFailed");
+        result.Error.Message.Should().Contain("Failed to retrieve users");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+
+    [Fact]
+    public async Task Handle_WhenAddressRepositoryThrows_ReturnsFailureResult()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "test@example.com",
+                FirstName = "Test",
+                LastName = "User",
+                Role = UserRole.Customer,
+                IsActive = true,
+                EmailVerified = true,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 1, 1, users);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ThrowsAsync(new Exception("Address fetch failed"));
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Users.GetDataTableFailed");
+        result.Error.Message.Should().Contain("Failed to retrieve users");
+    }
+
+    [Fact]
+    public async Task Handle_InactiveUsers_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var users = new List<UserDto>
+        {
+            new UserDto
+            {
+                Id = Guid.NewGuid(),
+                Email = "inactive@example.com",
+                FirstName = "Inactive",
+                LastName = "User",
+                Role = UserRole.Customer,
+                IsActive = false,
+                EmailVerified = false,
+                LastLogin = null,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            }
+        };
+
+        var datatableResult = new DataTableResult<UserDto>(1, 1, 1, users);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.AddressReader.GetByUserIdAsync(users[0].Id, CancellationToken))
+            .ReturnsAsync(new List<AddressDto>());
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var user = result.Value.Data.First();
+        user.IsActive.Should().BeFalse();
+        user.IsEmailVerified.Should().BeFalse();
+        user.LastLoginAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PaginationRequest_PassesCorrectParameters()
+    {
+        // Arrange
+        var datatableRequest = new DataTableRequest
+        {
+            Draw = 3,
+            Start = 20,
+            Length = 10
+        };
+
+        var query = new GetUsersDatatableQueryV1
+        {
+            Request = datatableRequest
+        };
+
+        var emptyUsers = new List<UserDto>();
+        var datatableResult = new DataTableResult<UserDto>(3, 100, 0, emptyUsers);
+
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.UserReader.GetDataTableAsync(datatableRequest, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Draw.Should().Be(3);
+        result.Value.RecordsTotal.Should().Be(100);
+
+        // Verify the exact request was passed to the repository
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.UserReader.GetDataTableAsync(
+                It.Is<DataTableRequest>(r => r.Draw == 3 && r.Start == 20 && r.Length == 10),
+                CancellationToken),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
- Introduced unit tests for `ChangeUserRoleCommandHandler`, `UpdateUserCommandHandler`, and `UpdateUserProfileCommandHandler`.
- Covered various edge cases, including validation errors, successful updates, and user not found scenarios.
- Utilized `FluentAssertions` for readable and expressive assertions.