### PR TITLE
Add null checks and internal visibility in payments infrastructure

### DIFF
--- a/Shopilent.Infrastructure.Payments/AssemblyInfo.cs
+++ b/Shopilent.Infrastructure.Payments/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Shopilent.Infrastructure.IntegrationTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Shopilent.Infrastructure.Payments/Providers/Base/PaymentProviderBase.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Base/PaymentProviderBase.cs
@@ -14,7 +14,7 @@ public abstract class PaymentProviderBase : IPaymentProvider
 
     protected PaymentProviderBase(ILogger logger)
     {
-        Logger = logger;
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public abstract PaymentProvider Provider { get; }

--- a/Shopilent.Infrastructure.Payments/Providers/Stripe/StripePaymentProvider.cs
+++ b/Shopilent.Infrastructure.Payments/Providers/Stripe/StripePaymentProvider.cs
@@ -32,8 +32,8 @@ internal class StripePaymentProvider : PaymentProviderBase
         ILogger<StripePaymentProvider> logger,
         StripeWebhookHandlerFactory webhookHandlerFactory) : base(logger)
     {
-        _settings = settings.Value;
-        _webhookHandlerFactory = webhookHandlerFactory;
+        _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
+        _webhookHandlerFactory = webhookHandlerFactory ?? throw new ArgumentNullException(nameof(webhookHandlerFactory));
 
         StripeConfiguration.ApiKey = _settings.SecretKey;
 


### PR DESCRIPTION
- Added `InternalsVisibleTo` for integration and proxy assemblies to `AssemblyInfo`.
- Introduced null checks in `StripePaymentProvider` and `PaymentProviderBase` constructors for improved validation and stability.