### PR TITLE
Add unit tests for catalog command handlers

### DIFF
--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/AddProductVariantCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/AddProductVariantCommandTests.cs
@@ -1,0 +1,474 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Imaging;
+using Shopilent.Application.Abstractions.S3Storage;
+using Shopilent.Application.Features.Catalog.Commands.AddProductVariant.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+using DomainAttribute = Shopilent.Domain.Catalog.Attribute;
+using CommandProductAttributeDto = Shopilent.Application.Features.Catalog.Commands.AddProductVariant.V1.ProductAttributeDto;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class AddProductVariantCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create a product with a specific ID for testing
+    /// </summary>
+    private static Product CreateProductWithId(Guid id, string name, string slug, decimal price)
+    {
+        var slugValue = Slug.Create(slug).Value;
+        var moneyValue = Money.Create(price, "USD").Value;
+        var product = Product.Create(name, slugValue, moneyValue).Value;
+        var idProperty = typeof(Product).GetProperty("Id");
+        idProperty?.SetValue(product, id);
+        return product;
+    }
+    
+    /// <summary>
+    /// Helper method to create an attribute with a specific ID for testing
+    /// </summary>
+    private static DomainAttribute CreateAttributeWithId(Guid id, string name, string displayName, AttributeType type, bool isVariant = true)
+    {
+        var attribute = DomainAttribute.Create(name, displayName, type).Value;
+        var idProperty = typeof(DomainAttribute).GetProperty("Id");
+        idProperty?.SetValue(attribute, id);
+        if (isVariant)
+        {
+            attribute.SetIsVariant(true);
+        }
+        return attribute;
+    }
+    
+    public AddProductVariantCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.MockS3StorageService.Object);
+        services.AddTransient(sp => Fixture.MockImageService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<AddProductVariantCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<AddProductVariantCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<AddProductVariantCommandV1>, AddProductVariantCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var attributeId = Guid.NewGuid();
+        
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-001",
+            Price = 19.99m,
+            StockQuantity = 100,
+            IsActive = true,
+            Attributes = new List<CommandProductAttributeDto>
+            {
+                new CommandProductAttributeDto { AttributeId = attributeId, Value = "Red" }
+            },
+            Metadata = new Dictionary<string, object> { { "key1", "value1" } }
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "color", "Color", AttributeType.Text, true);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock attribute retrieval (called twice - once for validation, once for adding)
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(new AttributeDto { Id = attributeId, Name = "color", IsVariant = true });
+            
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Capture the variant being added
+        ProductVariant capturedVariant = null;
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<ProductVariant>(), CancellationToken))
+            .Callback<ProductVariant, CancellationToken>((v, _) => capturedVariant = v)
+            .ReturnsAsync((ProductVariant v, CancellationToken _) => v);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the variant was created correctly
+        capturedVariant.Should().NotBeNull();
+        capturedVariant.ProductId.Should().Be(command.ProductId);
+        capturedVariant.Sku.Should().Be(command.Sku);
+        capturedVariant.Price?.Amount.Should().Be(command.Price);
+        capturedVariant.StockQuantity.Should().Be(command.StockQuantity);
+        capturedVariant.IsActive.Should().Be(command.IsActive);
+        
+        // Verify response
+        var response = result.Value;
+        response.Id.Should().Be(capturedVariant.Id);
+        response.ProductId.Should().Be(command.ProductId);
+        response.Sku.Should().Be(command.Sku);
+        response.Price.Should().Be(command.Price);
+        response.StockQuantity.Should().Be(command.StockQuantity);
+        response.IsActive.Should().Be(command.IsActive);
+        response.Attributes.Should().ContainSingle();
+        
+        // Verify the variant was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentProduct_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentProductId = Guid.NewGuid();
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = nonExistentProductId,
+            Sku = "VARIANT-002",
+            StockQuantity = 50
+        };
+        
+        // Mock that product doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentProductId, CancellationToken))
+            .ReturnsAsync((Product)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(nonExistentProductId).Code);
+        
+        // Verify the variant was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_DuplicateSku_ReturnsConflict()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "EXISTING-SKU",
+            StockQuantity = 50
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU already exists
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductVariantErrors.DuplicateSku(command.Sku).Code);
+        
+        // Verify the variant was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentAttribute_ReturnsNotFound()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var nonExistentAttributeId = Guid.NewGuid();
+        
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-003",
+            StockQuantity = 25,
+            Attributes = new List<CommandProductAttributeDto>
+            {
+                new CommandProductAttributeDto { AttributeId = nonExistentAttributeId, Value = "Blue" }
+            }
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock attribute doesn't exist
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentAttributeId, CancellationToken))
+            .ReturnsAsync((AttributeDto)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.NotFound(nonExistentAttributeId).Code);
+        
+        // Verify the variant was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NonVariantAttribute_ReturnsValidationError()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var attributeId = Guid.NewGuid();
+        
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-004",
+            StockQuantity = 25,
+            Attributes = new List<CommandProductAttributeDto>
+            {
+                new CommandProductAttributeDto { AttributeId = attributeId, Value = "Large" }
+            }
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock attribute exists but is not a variant attribute
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(new AttributeDto { Id = attributeId, Name = "description", IsVariant = false });
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.NotVariantAttribute("description").Code);
+        
+        // Verify the variant was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_WithoutPrice_UsesNullPrice()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-005",
+            Price = null, // No price specified
+            StockQuantity = 75
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Capture the variant being added
+        ProductVariant capturedVariant = null;
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<ProductVariant>(), CancellationToken))
+            .Callback<ProductVariant, CancellationToken>((v, _) => capturedVariant = v)
+            .ReturnsAsync((ProductVariant v, CancellationToken _) => v);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the variant was created with null price
+        capturedVariant.Should().NotBeNull();
+        capturedVariant.Price.Should().BeNull();
+        
+        // Verify response has null price
+        var response = result.Value;
+        response.Price.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task Handle_InactiveVariant_CreatesInactiveVariant()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-006",
+            StockQuantity = 10,
+            IsActive = false // Inactive variant
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Capture the variant being added
+        ProductVariant capturedVariant = null;
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<ProductVariant>(), CancellationToken))
+            .Callback<ProductVariant, CancellationToken>((v, _) => capturedVariant = v)
+            .ReturnsAsync((ProductVariant v, CancellationToken _) => v);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the variant was created as inactive
+        capturedVariant.Should().NotBeNull();
+        capturedVariant.IsActive.Should().BeFalse();
+        
+        // Verify response shows inactive status
+        var response = result.Value;
+        response.IsActive.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_CreatesVariantWithoutAuditInfo()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new AddProductVariantCommandV1
+        {
+            ProductId = productId,
+            Sku = "VARIANT-007",
+            StockQuantity = 30
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock SKU doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, null, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // Capture the variant being added
+        ProductVariant capturedVariant = null;
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<ProductVariant>(), CancellationToken))
+            .Callback<ProductVariant, CancellationToken>((v, _) => capturedVariant = v)
+            .ReturnsAsync((ProductVariant v, CancellationToken _) => v);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the variant was still created successfully
+        capturedVariant.Should().NotBeNull();
+        capturedVariant.ProductId.Should().Be(command.ProductId);
+        capturedVariant.Sku.Should().Be(command.Sku);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateAttributeCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateAttributeCommandTests.cs
@@ -1,0 +1,251 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.CreateAttribute.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Catalog.Errors;
+using Xunit;
+using DomainAttribute = Shopilent.Domain.Catalog.Attribute;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class CreateAttributeCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public CreateAttributeCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<CreateAttributeCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<CreateAttributeCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<CreateAttributeCommandV1>, CreateAttributeCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var command = new CreateAttributeCommandV1
+        {
+            Name = "color",
+            DisplayName = "Color",
+            Type = AttributeType.Text,
+            Filterable = true,
+            Searchable = false,
+            IsVariant = true,
+            Configuration = new Dictionary<string, object> { { "options", new[] { "Red", "Blue", "Green" } } }
+        };
+        
+        // Mock that name doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.NameExistsAsync(command.Name, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Capture the attribute being added
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .ReturnsAsync((DomainAttribute a, CancellationToken _) => a);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the attribute was created correctly
+        capturedAttribute.Should().NotBeNull();
+        capturedAttribute.Name.Should().Be(command.Name);
+        capturedAttribute.DisplayName.Should().Be(command.DisplayName);
+        capturedAttribute.Type.Should().Be(command.Type);
+        capturedAttribute.Filterable.Should().Be(command.Filterable);
+        capturedAttribute.Searchable.Should().Be(command.Searchable);
+        capturedAttribute.IsVariant.Should().Be(command.IsVariant);
+        
+        // Verify response
+        var response = result.Value;
+        response.Id.Should().Be(capturedAttribute.Id);
+        response.Name.Should().Be(command.Name);
+        response.DisplayName.Should().Be(command.DisplayName);
+        response.Type.Should().Be(command.Type);
+        response.Filterable.Should().Be(command.Filterable);
+        response.Searchable.Should().Be(command.Searchable);
+        response.IsVariant.Should().Be(command.IsVariant);
+        
+        // Verify the attribute was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_DuplicateName_ReturnsFailure()
+    {
+        // Arrange
+        var command = new CreateAttributeCommandV1
+        {
+            Name = "color",
+            DisplayName = "Color",
+            Type = AttributeType.Text
+        };
+        
+        // Mock that name already exists
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.NameExistsAsync(command.Name, null, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.DuplicateName(command.Name).Code);
+        
+        // Verify the attribute was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_WithConfiguration_SetsConfigurationCorrectly()
+    {
+        // Arrange
+        var configuration = new Dictionary<string, object>
+        {
+            { "min_length", 5 },
+            { "max_length", 50 },
+            { "pattern", "^[a-zA-Z]+$" }
+        };
+        
+        var command = new CreateAttributeCommandV1
+        {
+            Name = "description",
+            DisplayName = "Description",
+            Type = AttributeType.Text,
+            Configuration = configuration
+        };
+        
+        // Mock that name doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.NameExistsAsync(command.Name, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Capture the attribute being added
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .ReturnsAsync((DomainAttribute a, CancellationToken _) => a);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify configuration was set
+        capturedAttribute.Configuration.Should().NotBeNull();
+        capturedAttribute.Configuration.Count.Should().Be(3);
+        capturedAttribute.Configuration["min_length"].Should().Be(5);
+        capturedAttribute.Configuration["max_length"].Should().Be(50);
+        capturedAttribute.Configuration["pattern"].Should().Be("^[a-zA-Z]+$");
+    }
+    
+    [Fact]
+    public async Task Handle_WithoutConfiguration_CreatesAttributeWithEmptyConfiguration()
+    {
+        // Arrange
+        var command = new CreateAttributeCommandV1
+        {
+            Name = "size",
+            DisplayName = "Size",
+            Type = AttributeType.Number
+        };
+        
+        // Mock that name doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.NameExistsAsync(command.Name, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Capture the attribute being added
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .ReturnsAsync((DomainAttribute a, CancellationToken _) => a);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify default values
+        capturedAttribute.Filterable.Should().BeFalse();
+        capturedAttribute.Searchable.Should().BeFalse();
+        capturedAttribute.IsVariant.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_CreatesAttributeWithoutAuditInfo()
+    {
+        // Arrange
+        var command = new CreateAttributeCommandV1
+        {
+            Name = "brand",
+            DisplayName = "Brand",
+            Type = AttributeType.Text
+        };
+        
+        // Mock that name doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.NameExistsAsync(command.Name, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // Capture the attribute being added
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .ReturnsAsync((DomainAttribute a, CancellationToken _) => a);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify the attribute was still created successfully
+        capturedAttribute.Name.Should().Be(command.Name);
+        capturedAttribute.DisplayName.Should().Be(command.DisplayName);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateProductCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/CreateProductCommandTests.cs
@@ -1,0 +1,380 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.CreateProduct.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Application.Abstractions.Imaging;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class CreateProductCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public CreateProductCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.MockImageService.Object);
+        services.AddTransient(sp => Fixture.MockS3StorageService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<CreateProductCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<CreateProductCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<CreateProductCommandV1>, CreateProductCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task CreateProduct_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        
+        var command = new CreateProductCommandV1
+        {
+            Name = "Test Product",
+            Slug = "test-product",
+            Description = "Test product description",
+            BasePrice = 99.99m,
+            Currency = "USD",
+            Sku = "TEST-001",
+            CategoryIds = new List<Guid> { categoryId },
+            Attributes = new List<ProductAttributeDto>
+            {
+                new ProductAttributeDto
+                {
+                    AttributeId = Guid.NewGuid(),
+                    Value = "Test Value"
+                }
+            },
+            Images = new List<ProductImageDto>
+            {
+                new ProductImageDto
+                {
+                    AltText = "Test image",
+                    DisplayOrder = 1
+                }
+            }
+        };
+        
+        var category = new CategoryBuilder().WithId(categoryId).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(categoryId, CancellationToken))
+            .ReturnsAsync(category);
+            
+        // Mock image and storage services
+        Fixture.MockImageService
+            .Setup(service => service.ProcessProductImage(It.IsAny<Stream>()))
+            .ReturnsAsync(new ImageResult
+            {
+                MainImage = new MemoryStream(),
+                Thumbnail = new MemoryStream()
+            });
+            
+        Fixture.MockS3StorageService
+            .Setup(service => service.UploadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<string>.Success("products/test.jpg"));
+            
+        // Capture product being added
+        Product capturedProduct = null;
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken))
+            .Callback<Product, CancellationToken>((p, _) => capturedProduct = p)
+            .ReturnsAsync((Product p, CancellationToken _) => p);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Name.Should().Be(command.Name);
+        result.Value.Slug.Should().Be(command.Slug);
+        result.Value.Description.Should().Be(command.Description);
+        result.Value.BasePrice.Should().Be(command.BasePrice);
+        result.Value.Sku.Should().Be(command.Sku);
+        
+        // Verify product was created and saved
+        capturedProduct.Should().NotBeNull();
+        capturedProduct.Name.Should().Be(command.Name);
+        capturedProduct.Slug.Value.Should().Be(command.Slug);
+        
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken), 
+            Times.Once);
+            
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task CreateProduct_WithDuplicateSlug_ReturnsErrorResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var command = new CreateProductCommandV1
+        {
+            Name = "Test Product",
+            Slug = "existing-product-slug",
+            BasePrice = 99.99m,
+            Currency = "USD"
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId, isAdmin: true);
+        
+        // Mock that slug already exists
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.DuplicateSlug(command.Slug).Code);
+        
+        // Verify product was not saved
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken), 
+            Times.Never);
+            
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task CreateProduct_WithInvalidCategory_SkipsInvalidCategoryAndSucceeds()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var invalidCategoryId = Guid.NewGuid();
+        
+        var command = new CreateProductCommandV1
+        {
+            Name = "Test Product",
+            Slug = "test-product",
+            BasePrice = 99.99m,
+            Currency = "USD",
+            CategoryIds = new List<Guid> { invalidCategoryId }
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Category not found
+        Fixture.MockCategoryWriteRepository
+            .Setup(repo => repo.GetByIdAsync(invalidCategoryId, CancellationToken))
+            .ReturnsAsync((Category)null);
+            
+        // Capture product being added
+        Product capturedProduct = null;
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken))
+            .Callback<Product, CancellationToken>((p, _) => capturedProduct = p)
+            .ReturnsAsync((Product p, CancellationToken _) => p);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        // The business logic silently skips invalid categories rather than failing
+        capturedProduct.Should().NotBeNull();
+        capturedProduct.Categories.Should().BeEmpty(); // No categories should be added since the category was invalid
+        
+        // Verify product was saved
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken), 
+            Times.Once);
+    }
+    
+    
+    [Fact]
+    public async Task CreateProduct_WithImages_ProcessesAndUploadsImages()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var command = new CreateProductCommandV1
+        {
+            Name = "Test Product",
+            Slug = "test-product",
+            BasePrice = 99.99m,
+            Currency = "USD",
+            Images = new List<ProductImageDto>
+            {
+                new ProductImageDto
+                {
+                    AltText = "First image",
+                    DisplayOrder = 1
+                },
+                new ProductImageDto
+                {
+                    AltText = "Second image",
+                    DisplayOrder = 2
+                }
+            }
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock image processing
+        Fixture.MockImageService
+            .Setup(service => service.ProcessProductImage(It.IsAny<Stream>()))
+            .ReturnsAsync(new ImageResult
+            {
+                MainImage = new MemoryStream(),
+                Thumbnail = new MemoryStream()
+            });
+            
+        // Mock S3 storage
+        Fixture.MockS3StorageService
+            .Setup(service => service.UploadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<string>.Success("products/test-key"));
+            
+        // Capture product being added
+        Product capturedProduct = null;
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken))
+            .Callback<Product, CancellationToken>((p, _) => capturedProduct = p)
+            .ReturnsAsync((Product p, CancellationToken _) => p);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Images.Count.Should().Be(2);
+        
+        // Verify image processing was called for each image
+        Fixture.MockImageService.Verify(
+            service => service.ProcessProductImage(It.IsAny<Stream>()),
+            Times.Exactly(2));
+            
+        // Verify upload was called for each image (main + thumbnail for each)
+        Fixture.MockS3StorageService.Verify(
+            service => service.UploadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(4)); // 2 images x 2 uploads each
+    }
+    
+    [Fact]
+    public async Task CreateProduct_WithAttributes_AddsAttributesToProduct()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var attributeId1 = Guid.NewGuid();
+        var attributeId2 = Guid.NewGuid();
+        
+        var command = new CreateProductCommandV1
+        {
+            Name = "Test Product",
+            Slug = "test-product",
+            BasePrice = 99.99m,
+            Currency = "USD",
+            Attributes = new List<ProductAttributeDto>
+            {
+                new ProductAttributeDto
+                {
+                    AttributeId = attributeId1,
+                    Value = "Blue"
+                },
+                new ProductAttributeDto
+                {
+                    AttributeId = attributeId2,
+                    Value = "Large"
+                }
+            }
+        };
+        
+        var attribute1 = new AttributeBuilder().WithId(attributeId1).WithName("Color").Build();
+        var attribute2 = new AttributeBuilder().WithId(attributeId2).WithName("Size").Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId, isAdmin: true);
+        
+        // Mock repository calls
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, null, CancellationToken))
+            .ReturnsAsync(false);
+            
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId1, CancellationToken))
+            .ReturnsAsync(attribute1);
+            
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId2, CancellationToken))
+            .ReturnsAsync(attribute2);
+            
+        // Capture product being added
+        Product capturedProduct = null;
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Product>(), CancellationToken))
+            .Callback<Product, CancellationToken>((p, _) => capturedProduct = p)
+            .ReturnsAsync((Product p, CancellationToken _) => p);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Attributes.Count.Should().Be(2);
+        
+        var colorAttribute = result.Value.Attributes.FirstOrDefault(a => a.AttributeId == attributeId1);
+        colorAttribute.Should().NotBeNull();
+        colorAttribute.Values.Should().BeOfType<Dictionary<string, object>>();
+        var colorValues = (Dictionary<string, object>)colorAttribute.Values;
+        colorValues.Should().ContainKey("value");
+        colorValues["value"]?.ToString().Should().Be("Blue");
+        
+        var sizeAttribute = result.Value.Attributes.FirstOrDefault(a => a.AttributeId == attributeId2);
+        sizeAttribute.Should().NotBeNull();
+        sizeAttribute.Values.Should().BeOfType<Dictionary<string, object>>();
+        var sizeValues = (Dictionary<string, object>)sizeAttribute.Values;
+        sizeValues.Should().ContainKey("value");
+        sizeValues["value"]?.ToString().Should().Be("Large");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteAttributeCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteAttributeCommandTests.cs
@@ -1,0 +1,316 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.DeleteAttribute.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Common.Errors;
+using System.Reflection;
+using Xunit;
+using DomainAttribute = Shopilent.Domain.Catalog.Attribute;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class DeleteAttributeCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create an attribute with a specific ID for testing
+    /// </summary>
+    private static DomainAttribute CreateAttributeWithId(Guid id, string name, string displayName, AttributeType type)
+    {
+        var attribute = DomainAttribute.Create(name, displayName, type).Value;
+        var idProperty = typeof(DomainAttribute).GetProperty("Id");
+        idProperty?.SetValue(attribute, id);
+        return attribute;
+    }
+    
+    public DeleteAttributeCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<DeleteAttributeCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<DeleteAttributeCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<DeleteAttributeCommandV1>, DeleteAttributeCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = attributeId
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "color", "Color", AttributeType.Text);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Mock product search returns empty list (attribute not in use)
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.SearchAsync($"attribute:{existingAttribute.Name}", 
+                It.IsAny<Guid?>(), CancellationToken))
+            .ReturnsAsync(new List<ProductDto>());
+        
+        // Mock delete operation
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingAttribute, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify delete was called
+        Fixture.MockAttributeWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingAttribute, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentAttribute_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = nonExistentId
+        };
+        
+        // Mock that attribute doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentId, CancellationToken))
+            .ReturnsAsync((DomainAttribute)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.NotFound(nonExistentId).Code);
+        
+        // Verify delete was never called
+        Fixture.MockAttributeWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<DomainAttribute>(), CancellationToken), 
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_AttributeInUse_ReturnsConflict()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = attributeId
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "size", "Size", AttributeType.Text);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Mock product search returns products using this attribute
+        var productsUsingAttribute = new List<ProductDto>
+        {
+            // Create mock product DTOs - we just need the count to be > 0
+            new ProductDto { Id = Guid.NewGuid(), Name = "Product 1", Slug = "product-1" },
+            new ProductDto { Id = Guid.NewGuid(), Name = "Product 2", Slug = "product-2" }
+        };
+        
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.SearchAsync($"attribute:{existingAttribute.Name}", 
+                It.IsAny<Guid?>(), CancellationToken))
+            .ReturnsAsync(productsUsingAttribute);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attribute.InUse");
+        result.Error.Message.Should().Contain("Cannot delete attribute");
+        result.Error.Message.Should().Contain("2 products");
+        
+        // Verify delete was never called
+        Fixture.MockAttributeWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<DomainAttribute>(), CancellationToken), 
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_AttributeUsedBySingleProduct_ReturnsConflictWithCorrectCount()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = attributeId
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "brand", "Brand", AttributeType.Text);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Mock product search returns single product using this attribute
+        var productsUsingAttribute = new List<ProductDto>
+        {
+            new ProductDto { Id = Guid.NewGuid(), Name = "Single Product", Slug = "single-product" }
+        };
+        
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.SearchAsync($"attribute:{existingAttribute.Name}", 
+                It.IsAny<Guid?>(), CancellationToken))
+            .ReturnsAsync(productsUsingAttribute);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attribute.InUse");
+        result.Error.Message.Should().Contain("1 products");
+    }
+    
+    [Fact]
+    public async Task Handle_ProductSearchReturnsNull_DeletesSuccessfully()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = attributeId
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "material", "Material", AttributeType.Text);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Mock product search returns null (no products found)
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.SearchAsync($"attribute:{existingAttribute.Name}", 
+                It.IsAny<Guid?>(), CancellationToken))
+            .ReturnsAsync((List<ProductDto>)null);
+        
+        // Mock delete operation
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingAttribute, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify delete was called
+        Fixture.MockAttributeWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingAttribute, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_DeleteOperationThrowsException_ReturnsFailure()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new DeleteAttributeCommandV1
+        {
+            Id = attributeId
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "weight", "Weight", AttributeType.Number);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Mock product search returns empty list
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.SearchAsync($"attribute:{existingAttribute.Name}", 
+                It.IsAny<Guid?>(), CancellationToken))
+            .ReturnsAsync(new List<ProductDto>());
+        
+        // Mock delete operation throws exception
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingAttribute, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database error"));
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attribute.DeleteFailed");
+        result.Error.Message.Should().Be("Failed to delete attribute");
+        
+        // Verify delete was attempted
+        Fixture.MockAttributeWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingAttribute, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were not saved due to exception
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteProductCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteProductCommandTests.cs
@@ -1,0 +1,304 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.DeleteProduct.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class DeleteProductCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create a product with a specific ID for testing
+    /// </summary>
+    private static Product CreateProductWithId(Guid id, string name, string slug, decimal price)
+    {
+        var slugValue = Slug.Create(slug).Value;
+        var moneyValue = Money.Create(price, "USD").Value;
+        var product = Product.Create(name, slugValue, moneyValue).Value;
+        var idProperty = typeof(Product).GetProperty("Id");
+        idProperty?.SetValue(product, id);
+        return product;
+    }
+    
+    public DeleteProductCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<DeleteProductCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<DeleteProductCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<DeleteProductCommandV1>, DeleteProductCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = productId
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock delete operation
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingProduct, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify delete was called
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingProduct, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentProduct_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = nonExistentId
+        };
+        
+        // Mock that product doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentId, CancellationToken))
+            .ReturnsAsync((Product)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(nonExistentId).Code);
+        
+        // Verify delete was never called
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<Product>(), CancellationToken), 
+            Times.Never);
+            
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_DeleteOperationThrowsException_ReturnsFailure()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = productId
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock delete operation throws exception
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingProduct, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database error"));
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Product.DeleteFailed");
+        result.Error.Message.Should().Be("Failed to delete product");
+        
+        // Verify delete was attempted
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingProduct, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were not saved due to exception
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_SaveOperationThrowsException_ReturnsFailure()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = productId
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock delete operation succeeds
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingProduct, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Mock save operation throws exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection error"));
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Product.DeleteFailed");
+        result.Error.Message.Should().Be("Failed to delete product");
+        
+        // Verify delete was called
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingProduct, CancellationToken), 
+            Times.Once);
+            
+        // Verify save was attempted
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_AuthenticatedUser_DeletesSuccessfully()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = productId
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock delete operation
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingProduct, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify delete was called
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingProduct, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_DeletesSuccessfully()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new DeleteProductCommandV1
+        {
+            Id = productId
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock delete operation
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.DeleteAsync(existingProduct, CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify delete was called
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.DeleteAsync(existingProduct, CancellationToken), 
+            Times.Once);
+            
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteProductVariantCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/DeleteProductVariantCommandTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.DeleteProductVariant.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class DeleteProductVariantCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Helper method to create a ProductVariant with a specific ID for testing
+    /// </summary>
+    private static ProductVariant CreateProductVariantWithId(Guid variantId, Guid productId, string sku, decimal price, int stockQuantity)
+    {
+        var money = Money.Create(price, "USD").Value;
+        var variant = ProductVariant.Create(productId, sku, money, stockQuantity).Value;
+        var idProperty = typeof(ProductVariant).GetProperty("Id");
+        idProperty?.SetValue(variant, variantId);
+        return variant;
+    }
+
+    public DeleteProductVariantCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<DeleteProductVariantCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<DeleteProductVariantCommandV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<DeleteProductVariantCommandV1>, DeleteProductVariantCommandValidatorV1>();
+
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidVariantId_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new DeleteProductVariantCommandV1 { Id = variantId };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Mock delete operation
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.DeleteAsync(variant, CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        // Verify the variant was deleted
+        Fixture.MockProductVariantWriteRepository.Verify(
+            repo => repo.DeleteAsync(variant, CancellationToken),
+            Times.Once);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentVariantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var nonExistentVariantId = Guid.NewGuid();
+        var command = new DeleteProductVariantCommandV1 { Id = nonExistentVariantId };
+
+        // Mock that variant doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentVariantId, CancellationToken))
+            .ReturnsAsync((ProductVariant)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.NotFound");
+        result.Error.Message.Should().Contain($"Product variant with ID {nonExistentVariantId} was not found");
+
+        // Verify delete was not called
+        Fixture.MockProductVariantWriteRepository.Verify(
+            repo => repo.DeleteAsync(It.IsAny<ProductVariant>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new DeleteProductVariantCommandV1 { Id = variantId };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Mock delete operation to throw exception
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.DeleteAsync(variant, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.DeleteFailed");
+        result.Error.Message.Should().Be("Failed to delete product variant");
+    }
+
+    [Fact]
+    public async Task Handle_SaveEntitiesError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new DeleteProductVariantCommandV1 { Id = variantId };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Mock delete operation
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.DeleteAsync(variant, CancellationToken))
+            .Returns(Task.CompletedTask);
+
+        // Mock save entities to throw exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Failed to save changes"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.DeleteFailed");
+        result.Error.Message.Should().Be("Failed to delete product variant");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateAttributeCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateAttributeCommandTests.cs
@@ -1,0 +1,336 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateAttribute.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Catalog.Errors;
+using System.Reflection;
+using Xunit;
+using DomainAttribute = Shopilent.Domain.Catalog.Attribute;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateAttributeCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create an attribute with a specific ID for testing
+    /// </summary>
+    private static DomainAttribute CreateAttributeWithId(Guid id, string name, string displayName, AttributeType type)
+    {
+        var attribute = DomainAttribute.Create(name, displayName, type).Value;
+        var idProperty = typeof(DomainAttribute).GetProperty("Id");
+        idProperty?.SetValue(attribute, id);
+        return attribute;
+    }
+    
+    public UpdateAttributeCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateAttributeCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateAttributeCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateAttributeCommandV1>, UpdateAttributeCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = attributeId,
+            Name = "color",
+            DisplayName = "Updated Color",
+            Filterable = true,
+            Searchable = true,
+            IsVariant = false,
+            Configuration = new Dictionary<string, object> { { "options", new[] { "Red", "Blue", "Green", "Yellow" } } }
+        };
+        
+        // Create existing attribute with the same ID
+        var existingAttribute = CreateAttributeWithId(attributeId, "color", "Color", AttributeType.Text);
+        existingAttribute.SetFilterable(false);
+        existingAttribute.SetSearchable(false);
+        existingAttribute.SetIsVariant(true);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Capture the updated attribute
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the attribute was updated correctly
+        capturedAttribute.Should().NotBeNull();
+        capturedAttribute.DisplayName.Should().Be(command.DisplayName);
+        capturedAttribute.Filterable.Should().Be(command.Filterable);
+        capturedAttribute.Searchable.Should().Be(command.Searchable);
+        capturedAttribute.IsVariant.Should().Be(command.IsVariant);
+        
+        // Verify configuration was updated
+        capturedAttribute.Configuration.Should().NotBeNull();
+        capturedAttribute.Configuration.Should().ContainSingle();
+        capturedAttribute.Configuration.Keys.Should().Contain("options");
+        
+        // Verify response
+        var response = result.Value;
+        response.Id.Should().Be(attributeId);
+        response.DisplayName.Should().Be(command.DisplayName);
+        response.Filterable.Should().Be(command.Filterable);
+        response.Searchable.Should().Be(command.Searchable);
+        response.IsVariant.Should().Be(command.IsVariant);
+        
+        // Verify the attribute was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentAttribute_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentId = Guid.NewGuid();
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = nonExistentId,
+            Name = "color",
+            DisplayName = "Updated Color"
+        };
+        
+        // Mock that attribute doesn't exist
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentId, CancellationToken))
+            .ReturnsAsync((DomainAttribute)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.NotFound(nonExistentId).Code);
+        
+        // Verify the attribute was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UpdateProperties_UpdatesOnlyChangedProperties()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = attributeId,
+            Name = "size",
+            DisplayName = "Product Size",
+            Filterable = true,   // Changed from false
+            Searchable = false,  // Unchanged
+            IsVariant = true,    // Unchanged
+        };
+        
+        // Create existing attribute with initial values
+        var existingAttribute = CreateAttributeWithId(attributeId, "size", "Size", AttributeType.Number);
+        existingAttribute.SetFilterable(false);  // Will be changed
+        existingAttribute.SetSearchable(false);  // Will remain same
+        existingAttribute.SetIsVariant(true);    // Will remain same
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Capture the updated attribute
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify only changed properties were updated
+        capturedAttribute.DisplayName.Should().Be(command.DisplayName);
+        capturedAttribute.Filterable.Should().BeTrue();   // Changed from false to true
+        capturedAttribute.Searchable.Should().BeFalse();  // Remained false
+        capturedAttribute.IsVariant.Should().BeTrue();    // Remained true
+    }
+    
+    [Fact]
+    public async Task Handle_UpdateConfiguration_ReplacesEntireConfiguration()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var newConfiguration = new Dictionary<string, object>
+        {
+            { "new_option", "new_value" },
+            { "another_option", 42 }
+        };
+        
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = attributeId,
+            Name = "material",
+            DisplayName = "Material",
+            Configuration = newConfiguration
+        };
+        
+        // Create existing attribute with initial configuration
+        var existingAttribute = CreateAttributeWithId(attributeId, "material", "Material", AttributeType.Text);
+        existingAttribute.UpdateConfiguration("old_option", "old_value");
+        existingAttribute.UpdateConfiguration("existing_option", "existing_value");
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Capture the updated attribute
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify configuration was completely replaced
+        capturedAttribute.Configuration.Count.Should().Be(2);
+        capturedAttribute.Configuration.Keys.Should().Contain("new_option");
+        capturedAttribute.Configuration.Keys.Should().Contain("another_option");
+        capturedAttribute.Configuration.Keys.Should().NotContain("old_option");
+        capturedAttribute.Configuration.Keys.Should().NotContain("existing_option");
+        capturedAttribute.Configuration["new_option"].Should().Be("new_value");
+        capturedAttribute.Configuration["another_option"].Should().Be(42);
+    }
+    
+    [Fact]
+    public async Task Handle_NullConfiguration_DoesNotUpdateConfiguration()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = attributeId,
+            Name = "brand",
+            DisplayName = "Updated Brand",
+            Configuration = null
+        };
+        
+        // Create existing attribute with initial configuration
+        var existingAttribute = CreateAttributeWithId(attributeId, "brand", "Brand", AttributeType.Text);
+        existingAttribute.UpdateConfiguration("existing_option", "existing_value");
+        var originalConfigCount = existingAttribute.Configuration.Count;
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Capture the updated attribute
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify configuration was not modified
+        capturedAttribute.Configuration.Count.Should().Be(originalConfigCount);
+        capturedAttribute.Configuration.Keys.Should().Contain("existing_option");
+        capturedAttribute.Configuration["existing_option"].Should().Be("existing_value");
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_UpdatesAttributeWithoutAuditInfo()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var command = new UpdateAttributeCommandV1
+        {
+            Id = attributeId,
+            Name = "weight",
+            DisplayName = "Updated Weight"
+        };
+        
+        // Create existing attribute
+        var existingAttribute = CreateAttributeWithId(attributeId, "weight", "Weight", AttributeType.Number);
+        
+        // Mock attribute retrieval
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(existingAttribute);
+            
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // Capture the updated attribute
+        DomainAttribute capturedAttribute = null;
+        Fixture.MockAttributeWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<DomainAttribute>(), CancellationToken))
+            .Callback<DomainAttribute, CancellationToken>((a, _) => capturedAttribute = a)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedAttribute.Should().NotBeNull();
+        
+        // Verify the attribute was still updated successfully
+        capturedAttribute.DisplayName.Should().Be(command.DisplayName);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateProductCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateProductCommandTests.cs
@@ -1,0 +1,463 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Abstractions.Imaging;
+using Shopilent.Application.Abstractions.S3Storage;
+using Shopilent.Application.Features.Catalog.Commands.UpdateProduct.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateProductCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create a product with a specific ID for testing
+    /// </summary>
+    private static Product CreateProductWithId(Guid id, string name, string slug, decimal price, string currency = "USD")
+    {
+        var slugValue = Slug.Create(slug).Value;
+        var moneyValue = Money.Create(price, currency).Value;
+        var product = Product.Create(name, slugValue, moneyValue).Value;
+        var idProperty = typeof(Product).GetProperty("Id");
+        idProperty?.SetValue(product, id);
+        return product;
+    }
+    
+    public UpdateProductCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.MockS3StorageService.Object);
+        services.AddTransient(sp => Fixture.MockImageService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateProductCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateProductCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateProductCommandV1>, UpdateProductCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product Name",
+            Description = "Updated product description",
+            BasePrice = 39.99m,
+            Slug = "updated-product",
+            Sku = "UPD-001",
+            IsActive = true
+        };
+        
+        // Create existing product with different values
+        var existingProduct = CreateProductWithId(productId, "Old Product", "old-product", 29.99m);
+        // Set SKU via the Update method
+        var oldSlug = Slug.Create("old-product").Value;
+        var oldPrice = Money.Create(29.99m, "USD").Value;
+        existingProduct.Update("Old Product", oldSlug, oldPrice, null, "OLD-001");
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug doesn't exist for other products
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock SKU doesn't exist for other products
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, productId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // No need to mock UpdateAsync - the handler modifies the entity in-memory
+        // and saves via UnitOfWork.SaveChangesAsync
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product was updated correctly (check the existing product instance)
+        existingProduct.Name.Should().Be(command.Name);
+        existingProduct.Description.Should().Be(command.Description);
+        existingProduct.BasePrice.Amount.Should().Be(command.BasePrice);
+        existingProduct.Slug.Value.Should().Be(command.Slug);
+        existingProduct.Sku.Should().Be(command.Sku);
+        existingProduct.IsActive.Should().Be(command.IsActive.Value);
+        
+        // Verify response
+        var response = result.Value;
+        response.Id.Should().Be(productId);
+        response.Name.Should().Be(command.Name);
+        response.Description.Should().Be(command.Description);
+        response.BasePrice.Should().Be(command.BasePrice);
+        response.Slug.Should().Be(command.Slug);
+        response.Sku.Should().Be(command.Sku);
+        response.IsActive.Should().Be(command.IsActive.Value);
+        
+        // Verify the product was saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentProduct_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = nonExistentId,
+            Name = "Updated Product",
+            BasePrice = 19.99m,
+            Slug = "updated-product"
+        };
+        
+        // Mock that product doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentId, CancellationToken))
+            .ReturnsAsync((Product)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(nonExistentId).Code);
+        
+        // Verify the product was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_DuplicateSlug_ReturnsConflict()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product",
+            BasePrice = 19.99m,
+            Slug = "existing-slug"
+        };
+        
+        // Create existing product with different slug
+        var existingProduct = CreateProductWithId(productId, "Test Product", "original-slug", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug already exists for another product
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.DuplicateSlug(command.Slug).Code);
+        
+        // Verify the product was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_DuplicateSku_ReturnsConflict()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product",
+            BasePrice = 19.99m,
+            Slug = "updated-product",
+            Sku = "EXISTING-SKU"
+        };
+        
+        // Create existing product with different SKU
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        // Set SKU via the Update method
+        var originalSlug = Slug.Create("test-product").Value;
+        var originalPrice = Money.Create(29.99m, "USD").Value;
+        existingProduct.Update("Test Product", originalSlug, originalPrice, null, "ORIGINAL-SKU");
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(false);
+            
+        // Mock SKU already exists for another product
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, productId, CancellationToken))
+            .ReturnsAsync(true);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.DuplicateSku(command.Sku).Code);
+        
+        // Verify the product was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_SameSlugAsExisting_AllowsUpdate()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product Name",
+            BasePrice = 39.99m,
+            Slug = "existing-slug" // Same as current product slug
+        };
+        
+        // Create existing product with the same slug
+        var existingProduct = CreateProductWithId(productId, "Original Product", "existing-slug", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Note: No slug existence check should be made since the slug hasn't changed
+        
+        // No need to mock UpdateAsync - the handler modifies the entity in-memory
+        // and saves via UnitOfWork.SaveChangesAsync
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product was updated (check the existing product instance)
+        existingProduct.Name.Should().Be(command.Name);
+        existingProduct.BasePrice.Amount.Should().Be(command.BasePrice);
+        
+        // Verify slug existence was not checked (since it's the same)
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.SlugExistsAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_SameSkuAsExisting_AllowsUpdate()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product Name",
+            BasePrice = 39.99m,
+            Slug = "updated-product",
+            Sku = "EXISTING-SKU" // Same as current product SKU
+        };
+        
+        // Create existing product with the same SKU
+        var existingProduct = CreateProductWithId(productId, "Original Product", "original-product", 29.99m);
+        // Set SKU via the Update method
+        var originalSlug = Slug.Create("original-product").Value;
+        var originalPrice = Money.Create(29.99m, "USD").Value;
+        existingProduct.Update("Original Product", originalSlug, originalPrice, null, "EXISTING-SKU");
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Note: No SKU existence check should be made since the SKU hasn't changed
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue($"Expected success but got failure: {result.Error?.Message}");
+        
+        // Verify the product was updated (check the existing product instance)
+        existingProduct.Name.Should().Be(command.Name);
+        existingProduct.Sku.Should().Be(command.Sku);
+        existingProduct.BasePrice.Amount.Should().Be(command.BasePrice);
+        
+        // Verify SKU existence was not checked (since it's the same)
+        Fixture.MockProductWriteRepository.Verify(
+            repo => repo.SkuExistsAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_InvalidSlug_ReturnsValidationError()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product",
+            BasePrice = 19.99m,
+            Slug = "" // Invalid empty slug
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The exact error from Slug.Create validation for empty/invalid slugs
+        result.Error.Code.Should().Be("Category.SlugRequired");
+        
+        // Verify the product was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_InvalidPrice_ReturnsValidationError()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product",
+            BasePrice = -10.00m, // Invalid negative price
+            Slug = "updated-product"
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The exact error from Money.Create validation for negative amounts
+        result.Error.Code.Should().Be("Order.NegativeAmount");
+        
+        // Verify the product was not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_UpdatesProductWithoutAuditInfo()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductCommandV1
+        {
+            Id = productId,
+            Name = "Updated Product",
+            BasePrice = 25.99m,
+            Slug = "updated-product"
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Original Product", "original-product", 19.99m);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+            
+        // Mock slug doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.SlugExistsAsync(command.Slug, productId, CancellationToken))
+            .ReturnsAsync(false);
+        
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // No need to mock UpdateAsync - the handler modifies the entity in-memory
+        // and saves via UnitOfWork.SaveChangesAsync
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product was still updated successfully (check the existing product instance)
+        existingProduct.Name.Should().Be(command.Name);
+        existingProduct.BasePrice.Amount.Should().Be(command.BasePrice);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateProductStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateProductStatusCommandTests.cs
@@ -1,0 +1,305 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateProductStatus.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Catalog.ValueObjects;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateProductStatusCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    /// <summary>
+    /// Helper method to create a product with a specific ID for testing
+    /// </summary>
+    private static Product CreateProductWithId(Guid id, string name, string slug, decimal price, bool isActive = true)
+    {
+        var slugValue = Slug.Create(slug).Value;
+        var moneyValue = Money.Create(price, "USD").Value;
+        var product = isActive 
+            ? Product.Create(name, slugValue, moneyValue).Value
+            : Product.CreateInactive(name, slugValue, moneyValue).Value;
+        var idProperty = typeof(Product).GetProperty("Id");
+        idProperty?.SetValue(product, id);
+        return product;
+    }
+    
+    public UpdateProductStatusCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateProductStatusCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateProductStatusCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateProductStatusCommandV1>, UpdateProductStatusCommandValidatorV1>();
+        
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ActivateInactiveProduct_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = true
+        };
+        
+        // Create existing inactive product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, false);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product was activated
+        existingProduct.IsActive.Should().BeTrue();
+        
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_DeactivateActiveProduct_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = false
+        };
+        
+        // Create existing active product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, true);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Setup authenticated user for audit info
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product was deactivated
+        existingProduct.IsActive.Should().BeFalse();
+        
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ActivateAlreadyActiveProduct_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = true
+        };
+        
+        // Create existing active product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, true);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product remains active
+        existingProduct.IsActive.Should().BeTrue();
+        
+        // Verify the changes were saved (even though no change was made, the handler still saves)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_DeactivateAlreadyInactiveProduct_ReturnsSuccess()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = false
+        };
+        
+        // Create existing inactive product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, false);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product remains inactive
+        existingProduct.IsActive.Should().BeFalse();
+        
+        // Verify the changes were saved (even though no change was made, the handler still saves)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentProduct_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = nonExistentId,
+            IsActive = true
+        };
+        
+        // Mock that product doesn't exist
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentId, CancellationToken))
+            .ReturnsAsync((Product)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(nonExistentId).Code);
+        
+        // Verify the changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_UpdatesStatusWithoutAuditInfo()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = false
+        };
+        
+        // Create existing active product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, true);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Setup no authenticated user (uses default unauthenticated state)
+        // No setup needed as TestFixture defaults to unauthenticated state
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the product status was still updated successfully
+        existingProduct.IsActive.Should().BeFalse();
+        
+        // Verify the changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ExceptionDuringProcessing_ReturnsFailure()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var command = new UpdateProductStatusCommandV1
+        {
+            Id = productId,
+            IsActive = true
+        };
+        
+        // Create existing product
+        var existingProduct = CreateProductWithId(productId, "Test Product", "test-product", 29.99m, false);
+        
+        // Mock product retrieval
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(existingProduct);
+        
+        // Mock SaveChangesAsync to throw an exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database error"));
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Product.UpdateStatusFailed");
+        result.Error.Message.Should().Contain("Failed to update product status");
+        
+        // Verify SaveChangesAsync was attempted
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantCommandTests.cs
@@ -1,0 +1,375 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateVariant.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateVariantCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Helper method to create a ProductVariant with a specific ID for testing
+    /// </summary>
+    private static ProductVariant CreateProductVariantWithId(Guid variantId, Guid productId, string sku, decimal price, int stockQuantity)
+    {
+        var money = Money.Create(price, "USD").Value;
+        var variant = ProductVariant.Create(productId, sku, money, stockQuantity).Value;
+        var idProperty = typeof(ProductVariant).GetProperty("Id");
+        idProperty?.SetValue(variant, variantId);
+        return variant;
+    }
+
+    public UpdateVariantCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.MockS3StorageService.Object);
+        services.AddTransient(sp => Fixture.MockImageService.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateVariantCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateVariantCommandV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateVariantCommandV1>, UpdateVariantCommandValidatorV1>();
+
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidUpdateRequest_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            Sku = "UPDATED-SKU-001",
+            Price = 149.99m,
+            StockQuantity = 25,
+            IsActive = true,
+            Metadata = new Dictionary<string, object> { { "color", "blue" }, { "size", "large" } }
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "OLD-SKU-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Mock SKU uniqueness check
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(command.Sku, variantId, CancellationToken))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(variantId);
+        result.Value.ProductId.Should().Be(productId);
+        result.Value.Sku.Should().Be(command.Sku);
+        result.Value.Price.Should().Be(command.Price);
+        result.Value.StockQuantity.Should().Be(command.StockQuantity);
+        result.Value.IsActive.Should().Be(command.IsActive.Value);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentVariantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var nonExistentVariantId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = nonExistentVariantId,
+            Sku = "NEW-SKU-001",
+            Price = 99.99m
+        };
+
+        // Mock that variant doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentVariantId, CancellationToken))
+            .ReturnsAsync((ProductVariant)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.NotFound");
+        result.Error.Message.Should().Contain($"Product variant with ID {nonExistentVariantId} not found");
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateSku_ReturnsConflictError()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var duplicateSku = "EXISTING-SKU-001";
+
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            Sku = duplicateSku,
+            Price = 149.99m
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "OLD-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Mock SKU already exists
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.SkuExistsAsync(duplicateSku, variantId, CancellationToken))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.DuplicateSku");
+        result.Error.Message.Should().Contain($"A product variant with SKU '{duplicateSku}' already exists");
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_OnlyPriceUpdate_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            Price = 199.99m
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Price.Should().Be(command.Price);
+        result.Value.Sku.Should().Be("EXISTING-SKU-001"); // SKU should remain unchanged
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_OnlyStockQuantityUpdate_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            StockQuantity = 50
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StockQuantity.Should().Be(command.StockQuantity);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ActivateVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            IsActive = true
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Deactivate the variant first
+        existingVariant.Deactivate();
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsActive.Should().BeTrue();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DeactivateVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            IsActive = false
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsActive.Should().BeFalse();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidPrice_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            Price = -10.00m // Invalid negative price
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The specific error would depend on the Money.Create validation logic
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var command = new UpdateVariantCommandV1
+        {
+            Id = variantId,
+            Price = 149.99m
+        };
+
+        var existingVariant = CreateProductVariantWithId(variantId, productId, "EXISTING-SKU-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(existingVariant);
+
+        // Mock save entities to throw exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.UpdateFailed");
+        result.Error.Message.Should().Contain("Failed to update product variant");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantStatusCommandTests.cs
@@ -1,0 +1,327 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateVariantStatus.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateVariantStatusCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Helper method to create a ProductVariant with a specific ID for testing
+    /// </summary>
+    private static ProductVariant CreateProductVariantWithId(Guid variantId, Guid productId, string sku, decimal price, int stockQuantity)
+    {
+        var money = Money.Create(price, "USD").Value;
+        var variant = ProductVariant.Create(productId, sku, money, stockQuantity).Value;
+        var idProperty = typeof(ProductVariant).GetProperty("Id");
+        idProperty?.SetValue(variant, variantId);
+        return variant;
+    }
+
+    public UpdateVariantStatusCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateVariantStatusCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateVariantStatusCommandV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateVariantStatusCommandV1>, UpdateVariantStatusCommandValidatorV1>();
+
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ActivateVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = true
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Deactivate the variant first to test activation
+        variant.Deactivate();
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        variant.IsActive.Should().BeTrue();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DeactivateVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = false
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        variant.IsActive.Should().BeFalse();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentVariantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var nonExistentVariantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = nonExistentVariantId,
+            IsActive = true
+        };
+
+        // Mock that variant doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentVariantId, CancellationToken))
+            .ReturnsAsync((ProductVariant)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.NotFound");
+        result.Error.Message.Should().Contain($"Variant with ID {nonExistentVariantId} was not found");
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyActiveVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = true
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Variant is active by default, so no need to change status
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        variant.IsActive.Should().BeTrue();
+
+        // Verify changes were saved (even if status didn't change)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyInactiveVariant_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = false
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Deactivate the variant first
+        variant.Deactivate();
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        variant.IsActive.Should().BeFalse();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutAuthenticatedUser_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = false
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Don't set authenticated user (simulate anonymous operation)
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        variant.IsActive.Should().BeFalse();
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = true
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Mock save entities to throw exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.UpdateStatusFailed");
+        result.Error.Message.Should().Contain("Failed to update variant status");
+    }
+
+    [Fact]
+    public async Task Handle_VariantGetByIdError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStatusCommandV1
+        {
+            Id = variantId,
+            IsActive = true
+        };
+
+        // Mock variant retrieval to throw exception
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ThrowsAsync(new Exception("Database timeout"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.UpdateStatusFailed");
+        result.Error.Message.Should().Contain("Failed to update variant status");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantStockCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Commands/UpdateVariantStockCommandTests.cs
@@ -1,0 +1,356 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Commands.UpdateVariantStock.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Common.Results;
+using Shopilent.Domain.Sales.ValueObjects;
+using System.Reflection;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Commands;
+
+public class UpdateVariantStockCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Helper method to create a ProductVariant with a specific ID for testing
+    /// </summary>
+    private static ProductVariant CreateProductVariantWithId(Guid variantId, Guid productId, string sku, decimal price, int stockQuantity)
+    {
+        var money = Money.Create(price, "USD").Value;
+        var variant = ProductVariant.Create(productId, sku, money, stockQuantity).Value;
+        var idProperty = typeof(ProductVariant).GetProperty("Id");
+        idProperty?.SetValue(variant, variantId);
+        return variant;
+    }
+
+    public UpdateVariantStockCommandTests()
+    {
+        // Set up MediatR pipeline
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateVariantStockCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateVariantStockCommandV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateVariantStockCommandV1>, UpdateVariantStockCommandValidatorV1>();
+
+        // Get the mediator
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidStockUpdate_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var newStockQuantity = 50;
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = newStockQuantity
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(variantId);
+        result.Value.StockQuantity.Should().Be(newStockQuantity);
+        result.Value.IsActive.Should().Be(variant.IsActive);
+        variant.StockQuantity.Should().Be(newStockQuantity);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ZeroStockQuantity_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = 0
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StockQuantity.Should().Be(0);
+        variant.StockQuantity.Should().Be(0);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LargeStockQuantity_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var largeStockQuantity = 999999;
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = largeStockQuantity
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Setup authenticated user
+        var userId = Guid.NewGuid();
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StockQuantity.Should().Be(largeStockQuantity);
+        variant.StockQuantity.Should().Be(largeStockQuantity);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentVariantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var nonExistentVariantId = Guid.NewGuid();
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = nonExistentVariantId,
+            StockQuantity = 25
+        };
+
+        // Mock that variant doesn't exist
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(nonExistentVariantId, CancellationToken))
+            .ReturnsAsync((ProductVariant)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.NotFound");
+        result.Error.Message.Should().Contain($"Variant with ID {nonExistentVariantId} not found");
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NegativeStockQuantity_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var negativeStock = -10;
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = negativeStock
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The specific error would depend on the SetStockQuantity validation logic
+
+        // Verify changes were not saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutAuthenticatedUser_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var newStockQuantity = 30;
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = newStockQuantity
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Don't set authenticated user (simulate anonymous operation)
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StockQuantity.Should().Be(newStockQuantity);
+
+        // Verify changes were saved
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = 25
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, 10);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Mock save entities to throw exception
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.UpdateStockFailed");
+    }
+
+    [Fact]
+    public async Task Handle_VariantGetByIdError_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = 25
+        };
+
+        // Mock variant retrieval to throw exception
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ThrowsAsync(new Exception("Database timeout"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Variant.UpdateStockFailed");
+    }
+
+    [Fact]
+    public async Task Handle_StockUpdateSameValue_ReturnsSuccessResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var currentStock = 10;
+        var command = new UpdateVariantStockCommandV1
+        {
+            Id = variantId,
+            StockQuantity = currentStock // Same as current stock
+        };
+
+        var productId = Guid.NewGuid();
+        var variant = CreateProductVariantWithId(variantId, productId, "TEST-VAR-001", 99.99m, currentStock);
+
+        // Mock variant retrieval
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StockQuantity.Should().Be(currentStock);
+
+        // Verify changes were saved (even if stock didn't change)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAllAttributesQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAllAttributesQueryHandlerTests.cs
@@ -1,0 +1,196 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetAllAttributes.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetAllAttributesQueryHandlerTests : TestBase
+{
+    private readonly GetAllAttributesQueryHandlerV1 _handler;
+
+    public GetAllAttributesQueryHandlerTests()
+    {
+        _handler = new GetAllAttributesQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetAllAttributesQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingAttributes_ReturnsAllAttributes()
+    {
+        // Arrange
+        var query = new GetAllAttributesQueryV1();
+
+        var attributes = new List<AttributeDto>
+        {
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Color",
+                DisplayName = "Product Color",
+                Type = AttributeType.Text,
+                Filterable = true,
+                Searchable = true,
+                IsVariant = false,
+                Configuration = new Dictionary<string, object>(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Size",
+                DisplayName = "Product Size", 
+                Type = AttributeType.Select,
+                Filterable = true,
+                Searchable = true,
+                IsVariant = true,
+                Configuration = new Dictionary<string, object>(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Weight",
+                DisplayName = "Product Weight",
+                Type = AttributeType.Number,
+                Filterable = false,
+                Searchable = false,
+                IsVariant = false,
+                Configuration = new Dictionary<string, object>(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(attributes);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Count.Should().Be(3);
+        result.Value.Should().Contain(a => a.Name == "Color");
+        result.Value.Should().Contain(a => a.Name == "Size");
+        result.Value.Should().Contain(a => a.Name == "Weight");
+    }
+
+    [Fact]
+    public async Task Handle_WithNoAttributes_ReturnsEmptyList()
+    {
+        // Arrange
+        var query = new GetAllAttributesQueryV1();
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(new List<AttributeDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetAllAttributesQueryV1();
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attributes.GetAllFailed");
+        result.Error.Message.Should().Contain("Test exception");
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var query = new GetAllAttributesQueryV1();
+        
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(new List<AttributeDto>());
+
+        // Act
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        query.CacheKey.Should().Be("all-attributes");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(30));
+    }
+    
+    [Fact]
+    public async Task Handle_VerifiesNoFilteringIsApplied()
+    {
+        // Arrange
+        var query = new GetAllAttributesQueryV1();
+        
+        var allAttributes = new List<AttributeDto>
+        {
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Active Attribute",
+                DisplayName = "Active Attribute",
+                Type = AttributeType.Text,
+                Filterable = true,
+                Searchable = true,
+                IsVariant = false,
+                Configuration = new Dictionary<string, object>(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Inactive Attribute",
+                DisplayName = "Inactive Attribute", 
+                Type = AttributeType.Text,
+                Filterable = false,
+                Searchable = false,
+                IsVariant = false,
+                Configuration = new Dictionary<string, object>(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.ListAllAsync(CancellationToken))
+            .ReturnsAsync(allAttributes);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Count.Should().Be(2);
+        result.Value.Should().Contain(a => a.Name == "Active Attribute");
+        result.Value.Should().Contain(a => a.Name == "Inactive Attribute");
+        
+        Fixture.MockAttributeReadRepository.Verify(
+            repo => repo.ListAllAsync(CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAttributeQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAttributeQueryHandlerTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetAttribute.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetAttributeQueryHandlerTests : TestBase
+{
+    private readonly GetAttributeQueryHandlerV1 _handler;
+    
+    public GetAttributeQueryHandlerTests()
+    {
+        _handler = new GetAttributeQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetAttributeQueryHandlerV1>());
+    }
+    
+    [Fact]
+    public async Task Handle_WithValidAttributeId_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var attributeDto = new AttributeDto
+        {
+            Id = attributeId,
+            Name = "Color",
+            DisplayName = "Product Color",
+            Type = AttributeType.Text,
+            Filterable = true,
+            Searchable = true,
+            IsVariant = false,
+            Configuration = new Dictionary<string, object>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(attributeDto);
+            
+        var query = new GetAttributeQueryV1 { Id = attributeId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(attributeId);
+        result.Value.Name.Should().Be(attributeDto.Name);
+        result.Value.DisplayName.Should().Be(attributeDto.DisplayName);
+        result.Value.Type.Should().Be(attributeDto.Type);
+    }
+    
+    [Fact]
+    public async Task Handle_WithInvalidAttributeId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync((AttributeDto)null);
+            
+        var query = new GetAttributeQueryV1 { Id = attributeId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(AttributeErrors.NotFound(attributeId).Code);
+    }
+    
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+            
+        var query = new GetAttributeQueryV1 { Id = attributeId };
+        
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attribute.GetFailed");
+        result.Error.Message.Should().Contain("Test exception");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var attributeId = Guid.NewGuid();
+        var query = new GetAttributeQueryV1 { Id = attributeId };
+        
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetByIdAsync(attributeId, CancellationToken))
+            .ReturnsAsync(new AttributeDto { Id = attributeId, Name = "Test" });
+
+        // Act
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        query.CacheKey.Should().Be($"attribute-{attributeId}");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(30));
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAttributesDatatableQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetAttributesDatatableQueryHandlerTests.cs
@@ -1,0 +1,236 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetAttributesDatatable.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Enums;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetAttributesDatatableQueryHandlerTests : TestBase
+{
+    private readonly GetAttributesDatatableQueryHandlerV1 _handler;
+
+    public GetAttributesDatatableQueryHandlerTests()
+    {
+        _handler = new GetAttributesDatatableQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetAttributesDatatableQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_ReturnsFormattedDatatableResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10,
+            Search = new DataTableSearch { Value = "color" },
+            Order = new List<DataTableOrder>
+            {
+                new DataTableOrder { Column = 0, Dir = "asc" }
+            },
+            Columns = new List<DataTableColumn>
+            {
+                new DataTableColumn { Data = "name", Name = "Name", Searchable = true, Orderable = true }
+            }
+        };
+
+        var query = new GetAttributesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var attributes = new List<AttributeDto>
+        {
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Color",
+                DisplayName = "Product Color",
+                Type = AttributeType.Text,
+                Filterable = true,
+                Searchable = true,
+                IsVariant = false,
+                Configuration = new Dictionary<string, object> { { "required", true } },
+                CreatedAt = DateTime.UtcNow.AddDays(-10),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new AttributeDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Size",
+                DisplayName = "Product Size",
+                Type = AttributeType.Select,
+                Filterable = true,
+                Searchable = false,
+                IsVariant = true,
+                Configuration = new Dictionary<string, object> { { "options", new[] { "S", "M", "L" } } },
+                CreatedAt = DateTime.UtcNow.AddDays(-5),
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        var datatableResult = new DataTableResult<AttributeDto>(
+            draw: 1,
+            recordsTotal: 2,
+            recordsFiltered: 2,
+            data: attributes);
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(2);
+        result.Value.RecordsFiltered.Should().Be(2);
+        result.Value.Data.Count.Should().Be(2);
+
+        var firstAttribute = result.Value.Data.First();
+        firstAttribute.Name.Should().Be("Color");
+        firstAttribute.DisplayName.Should().Be("Product Color");
+        firstAttribute.Type.Should().Be("Text");
+        firstAttribute.Filterable.Should().BeTrue();
+        firstAttribute.Searchable.Should().BeTrue();
+        firstAttribute.IsVariant.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyResult_ReturnsEmptyDatatableResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetAttributesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var datatableResult = new DataTableResult<AttributeDto>(
+            draw: 1,
+            recordsTotal: 0,
+            recordsFiltered: 0,
+            data: new List<AttributeDto>());
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(0);
+        result.Value.RecordsFiltered.Should().Be(0);
+        result.Value.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetAttributesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetDataTableAsync(request, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Attributes.GetDataTableFailed");
+        result.Error.Message.Should().Contain("Test exception");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCorrectMappingFromAttributeToDto()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetAttributesDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var sourceAttribute = new AttributeDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Weight",
+            DisplayName = "Product Weight",
+            Type = AttributeType.Number,
+            Filterable = false,
+            Searchable = true,
+            IsVariant = false,
+            Configuration = new Dictionary<string, object> 
+            { 
+                { "unit", "kg" }, 
+                { "precision", 2 } 
+            },
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-2)
+        };
+
+        var datatableResult = new DataTableResult<AttributeDto>(
+            draw: 1,
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            data: new List<AttributeDto> { sourceAttribute });
+
+        Fixture.MockAttributeReadRepository
+            .Setup(repo => repo.GetDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        var mappedAttribute = result.Value.Data.First();
+        mappedAttribute.Id.Should().Be(sourceAttribute.Id);
+        mappedAttribute.Name.Should().Be(sourceAttribute.Name);
+        mappedAttribute.DisplayName.Should().Be(sourceAttribute.DisplayName);
+        mappedAttribute.Type.Should().Be("Number");
+        mappedAttribute.Filterable.Should().Be(sourceAttribute.Filterable);
+        mappedAttribute.Searchable.Should().Be(sourceAttribute.Searchable);
+        mappedAttribute.IsVariant.Should().Be(sourceAttribute.IsVariant);
+        mappedAttribute.Configuration.Should().BeEquivalentTo(sourceAttribute.Configuration);
+        mappedAttribute.CreatedAt.Should().Be(sourceAttribute.CreatedAt);
+        mappedAttribute.UpdatedAt.Should().Be(sourceAttribute.UpdatedAt);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetPaginatedProductsQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetPaginatedProductsQueryHandlerTests.cs
@@ -1,0 +1,308 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Abstractions.Search;
+using Shopilent.Application.Features.Catalog.Queries.GetPaginatedProducts.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetPaginatedProductsQueryHandlerTests : TestBase
+{
+    private readonly GetPaginatedProductsQueryHandlerV1 _handler;
+    private readonly Mock<ISearchService> _mockSearchService;
+
+    public GetPaginatedProductsQueryHandlerTests()
+    {
+        _mockSearchService = new Mock<ISearchService>();
+        _handler = new GetPaginatedProductsQueryHandlerV1(
+            _mockSearchService.Object,
+            Fixture.GetLogger<GetPaginatedProductsQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SearchQuery = "test",
+            IsActiveOnly = true,
+            SortColumn = "name",
+            SortDescending = false
+        };
+
+        var products = new ProductSearchResultDto[]
+        {
+            new ProductSearchResultDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Product 1",
+                Slug = "test-product-1",
+                BasePrice = 29.99m,
+                IsActive = true,
+                HasStock = true,
+                TotalStock = 50
+            },
+            new ProductSearchResultDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Product 2",
+                Slug = "test-product-2",
+                BasePrice = 49.99m,
+                IsActive = true,
+                HasStock = false,
+                TotalStock = 0
+            }
+        };
+
+        var searchResponse = new SearchResponse<ProductSearchResultDto>
+        {
+            Items = products,
+            TotalCount = 25,
+            PageNumber = 1,
+            PageSize = 10,
+            TotalPages = 3
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ReturnsAsync(Result.Success(searchResponse));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(25);
+        result.Value.Items.Length.Should().Be(2);
+        result.Value.Items.First().Name.Should().Be("Test Product 1");
+        
+        _mockSearchService.Verify(
+            service => service.SearchProductsAsync(It.Is<SearchRequest>(r => 
+                r.Query == "test" &&
+                r.ActiveOnly == true &&
+                r.PageNumber == 1 &&
+                r.PageSize == 10 &&
+                r.SortBy == "Name" &&
+                r.SortDescending == false
+            ), CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyQuery_ReturnsAllProducts()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            PageNumber = 1,
+            PageSize = 20,
+            SearchQuery = "",
+            IsActiveOnly = false
+        };
+
+        var searchResponse = new SearchResponse<ProductSearchResultDto>
+        {
+            Items = new ProductSearchResultDto[0],
+            TotalCount = 0,
+            PageNumber = 1,
+            PageSize = 20,
+            TotalPages = 0
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ReturnsAsync(Result.Success(searchResponse));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(0);
+        result.Value.Items.Length.Should().Be(0);
+
+        _mockSearchService.Verify(
+            service => service.SearchProductsAsync(It.Is<SearchRequest>(r => 
+                r.Query == "" &&
+                r.ActiveOnly == false
+            ), CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithFiltersAndPriceRange_PassesCorrectParameters()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            PageNumber = 2,
+            PageSize = 5,
+            SearchQuery = "electronics",
+            CategorySlugs = new[] { "smartphones", "laptops" },
+            AttributeFilters = new Dictionary<string, string[]>
+            {
+                { "brand", new[] { "apple", "samsung" } },
+                { "color", new[] { "black", "white" } }
+            },
+            PriceMin = 100,
+            PriceMax = 1000,
+            InStockOnly = true,
+            IsActiveOnly = true,
+            SortColumn = "price",
+            SortDescending = true
+        };
+
+        var searchResponse = new SearchResponse<ProductSearchResultDto>
+        {
+            Items = new ProductSearchResultDto[0],
+            TotalCount = 50,
+            PageNumber = 2,
+            PageSize = 5,
+            TotalPages = 10
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ReturnsAsync(Result.Success(searchResponse));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        _mockSearchService.Verify(
+            service => service.SearchProductsAsync(It.Is<SearchRequest>(r => 
+                r.Query == "electronics" &&
+                r.CategorySlugs.SequenceEqual(new[] { "smartphones", "laptops" }) &&
+                r.AttributeFilters["brand"].SequenceEqual(new[] { "apple", "samsung" }) &&
+                r.AttributeFilters["color"].SequenceEqual(new[] { "black", "white" }) &&
+                r.PriceMin == 100 &&
+                r.PriceMax == 1000 &&
+                r.InStockOnly == true &&
+                r.ActiveOnly == true &&
+                r.PageNumber == 2 &&
+                r.PageSize == 5 &&
+                r.SortBy == "BasePrice" &&
+                r.SortDescending == true
+            ), CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSearchServiceReturnsFailure_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            SearchQuery = "test"
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ReturnsAsync(Result.Failure<SearchResponse<ProductSearchResultDto>>(
+                Error.Failure("Search.Failed", "Search service error")));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Search.Failed");
+        result.Error.Message.Should().Be("Search service error");
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            SearchQuery = "test"
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ThrowsAsync(new Exception("Search service exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Products.GetPaginatedFailed");
+        result.Error.Message.Should().Contain("Search service exception");
+    }
+
+    [Theory]
+    [InlineData("name", "Name")]
+    [InlineData("price", "BasePrice")]
+    [InlineData("created", "CreatedAt")]
+    [InlineData("updated", "UpdatedAt")]
+    [InlineData("unknown", "Name")]
+    [InlineData("", "Name")]
+    public async Task Handle_VerifiesSortColumnMapping(string inputColumn, string expectedColumn)
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            SortColumn = inputColumn
+        };
+
+        var searchResponse = new SearchResponse<ProductSearchResultDto>
+        {
+            Items = new ProductSearchResultDto[0],
+            TotalCount = 0,
+            PageNumber = 1,
+            PageSize = 10,
+            TotalPages = 0
+        };
+
+        _mockSearchService
+            .Setup(service => service.SearchProductsAsync(It.IsAny<SearchRequest>(), CancellationToken))
+            .ReturnsAsync(Result.Success(searchResponse));
+
+        // Act
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        _mockSearchService.Verify(
+            service => service.SearchProductsAsync(It.Is<SearchRequest>(r => 
+                r.SortBy == expectedColumn
+            ), CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var query = new GetPaginatedProductsQueryV1
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SearchQuery = "test",
+            CategorySlugs = new[] { "electronics" },
+            PriceMin = 50,
+            PriceMax = 200,
+            InStockOnly = true
+        };
+
+        // Act - Cache properties are read-only and set during construction
+        // We verify they have expected values
+
+        // Assert
+        query.CacheKey.Should().NotBeEmpty();
+        query.CacheKey.Should().Contain("products-page-1");
+        query.CacheKey.Should().Contain("size-10");
+        query.CacheKey.Should().Contain("electronics");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductQueryTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductQueryTests.cs
@@ -1,0 +1,308 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetProduct.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Catalog.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetProductQueryTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public GetProductQueryTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetProductQueryHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetProductQueryV1>();
+        });
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task GetProduct_WithValidId_ReturnsProduct()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var attributeId = Guid.NewGuid();
+        
+        var query = new GetProductQueryV1 { Id = productId };
+        
+        var productDto = new ProductDetailDto
+        {
+            Id = productId,
+            Name = "Test Product",
+            Slug = "test-product",
+            Description = "Test product description",
+            BasePrice = 99.99m,
+            Currency = "USD",
+            Sku = "TEST-001",
+            IsActive = true,
+            Metadata = new Dictionary<string, object>(),
+            Images = new List<ProductImageDto>
+            {
+                new ProductImageDto
+                {
+                    ImageKey = "products/test-image.jpg",
+                    ThumbnailKey = "products/test-image-thumb.jpg",
+                    AltText = "Product image",
+                    DisplayOrder = 1
+                }
+            },
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            Categories = new List<CategoryDto>(),
+            Attributes = new List<ProductAttributeDto>(),
+            Variants = new List<ProductVariantDto>(),
+            CreatedBy = Guid.NewGuid(),
+            ModifiedBy = Guid.NewGuid(),
+            LastModified = DateTime.UtcNow.AddDays(-1)
+        };
+        
+        // Mock repository calls
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(productId);
+        result.Value.Name.Should().Be("Test Product");
+        result.Value.Slug.Should().Be("test-product");
+        result.Value.BasePrice.Should().Be(99.99m);
+        result.Value.Currency.Should().Be("USD");
+        result.Value.IsActive.Should().BeTrue();
+        
+        // Verify images
+        result.Value.Images.Should().ContainSingle();
+        result.Value.Images.First().ImageKey.Should().Be("products/test-image.jpg");
+        result.Value.Images.First().AltText.Should().Be("Product image");
+        
+        // Verify repository was called correctly
+        Fixture.MockProductReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(productId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetProduct_WithNonExistentId_ReturnsErrorResult()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductQueryV1 { Id = productId };
+        
+        // Mock repository calls - product not found
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(productId, CancellationToken))
+            .ReturnsAsync((ProductDetailDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(productId).Code);
+        
+        // Verify repository was called correctly
+        Fixture.MockProductReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(productId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetProduct_WithInactiveProduct_ReturnsProduct()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductQueryV1 { Id = productId };
+        
+        var inactiveProductDto = new ProductDetailDto
+        {
+            Id = productId,
+            Name = "Inactive Product",
+            Slug = "inactive-product",
+            BasePrice = 50.00m,
+            Currency = "USD",
+            IsActive = false, // Inactive product
+            Metadata = new Dictionary<string, object>(),
+            Images = new List<ProductImageDto>(),
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            Categories = new List<CategoryDto>(),
+            Attributes = new List<ProductAttributeDto>(),
+            Variants = new List<ProductVariantDto>(),
+            CreatedBy = Guid.NewGuid(),
+            ModifiedBy = Guid.NewGuid(),
+            LastModified = DateTime.UtcNow.AddDays(-1)
+        };
+        
+        // Mock repository calls
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(inactiveProductDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(productId);
+        result.Value.IsActive.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task GetProduct_WithComplexProductData_ReturnsAllData()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductQueryV1 { Id = productId };
+        
+        var complexProductDto = new ProductDetailDto
+        {
+            Id = productId,
+            Name = "Complex Product",
+            Slug = "complex-product",
+            Description = "A complex product with multiple images",
+            BasePrice = 299.99m,
+            Currency = "USD",
+            Sku = "COMPLEX-001",
+            IsActive = true,
+            Metadata = new Dictionary<string, object>
+            {
+                ["categories"] = new[] { "Electronics", "Smartphones" },
+                ["attributes"] = new Dictionary<string, string>
+                {
+                    ["Color"] = "Space Gray",
+                    ["Storage"] = "128GB",
+                    ["Brand"] = "TestBrand"
+                }
+            },
+            Images = new List<ProductImageDto>
+            {
+                new ProductImageDto
+                {
+                    ImageKey = "products/image1.jpg",
+                    ThumbnailKey = "products/image1-thumb.jpg",
+                    AltText = "Front view",
+                    DisplayOrder = 1
+                },
+                new ProductImageDto
+                {
+                    ImageKey = "products/image2.jpg",
+                    ThumbnailKey = "products/image2-thumb.jpg",
+                    AltText = "Back view",
+                    DisplayOrder = 2
+                },
+                new ProductImageDto
+                {
+                    ImageKey = "products/image3.jpg",
+                    ThumbnailKey = "products/image3-thumb.jpg",
+                    AltText = "Side view",
+                    DisplayOrder = 3
+                }
+            },
+            CreatedAt = DateTime.UtcNow.AddDays(-60),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5),
+            Categories = new List<CategoryDto>(),
+            Attributes = new List<ProductAttributeDto>(),
+            Variants = new List<ProductVariantDto>(),
+            CreatedBy = Guid.NewGuid(),
+            ModifiedBy = Guid.NewGuid(),
+            LastModified = DateTime.UtcNow.AddDays(-5)
+        };
+        
+        // Mock repository calls
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(complexProductDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(productId);
+        result.Value.Name.Should().Be("Complex Product");
+        result.Value.BasePrice.Should().Be(299.99m);
+        
+        // Verify metadata contains categories and attributes
+        result.Value.Metadata.Should().NotBeNull();
+        result.Value.Metadata.Should().ContainKey("categories");
+        result.Value.Metadata.Should().ContainKey("attributes");
+        
+        // Verify multiple images in correct order
+        result.Value.Images.Count.Should().Be(3);
+        var orderedImages = result.Value.Images.OrderBy(i => i.DisplayOrder).ToList();
+        orderedImages[0].AltText.Should().Be("Front view");
+        orderedImages[1].AltText.Should().Be("Back view");
+        orderedImages[2].AltText.Should().Be("Side view");
+    }
+    
+    [Fact]
+    public async Task GetProduct_CachesBehaviorCanBeVerified()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductQueryV1 { Id = productId };
+        
+        var productDto = new ProductDetailDto
+        {
+            Id = productId,
+            Name = "Cached Product",
+            Slug = "cached-product",
+            BasePrice = 25.00m,
+            Currency = "USD",
+            IsActive = true,
+            Metadata = new Dictionary<string, object>(),
+            Images = new List<ProductImageDto>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Categories = new List<CategoryDto>(),
+            Attributes = new List<ProductAttributeDto>(),
+            Variants = new List<ProductVariantDto>(),
+            CreatedBy = Guid.NewGuid(),
+            ModifiedBy = Guid.NewGuid(),
+            LastModified = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+        
+        // Act - Call twice to verify caching behavior
+        var result1 = await _mediator.Send(query, CancellationToken);
+        var result2 = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result1.IsSuccess.Should().BeTrue();
+        result2.IsSuccess.Should().BeTrue();
+        result1.Value.Id.Should().Be(result2.Value.Id);
+        
+        // Note: The actual caching behavior depends on the ICachedQuery implementation
+        // This test verifies the query can be called multiple times successfully
+        Fixture.MockProductReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(productId, CancellationToken), 
+            Times.Exactly(2)); // Without cache, repository is called each time
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductVariantsQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductVariantsQueryHandlerTests.cs
@@ -1,0 +1,252 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetProductVariants.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetProductVariantsQueryHandlerTests : TestBase
+{
+    private readonly GetProductVariantsQueryHandlerV1 _handler;
+
+    public GetProductVariantsQueryHandlerTests()
+    {
+        _handler = new GetProductVariantsQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetProductVariantsQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidProductId_ReturnsProductVariants()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        var productDto = new ProductDto
+        {
+            Id = productId,
+            Name = "Test Product",
+            IsActive = true
+        };
+
+        var variants = new List<ProductVariantDto>
+        {
+            new ProductVariantDto
+            {
+                Id = Guid.NewGuid(),
+                ProductId = productId,
+                Sku = "TP-001-S",
+                Price = 99.99m,
+                Currency = "USD",
+                StockQuantity = 50,
+                IsActive = true
+            },
+            new ProductVariantDto
+            {
+                Id = Guid.NewGuid(),
+                ProductId = productId,
+                Sku = "TP-001-M",
+                Price = 109.99m,
+                Currency = "USD",
+                StockQuantity = 30,
+                IsActive = true
+            },
+            new ProductVariantDto
+            {
+                Id = Guid.NewGuid(),
+                ProductId = productId,
+                Sku = "TP-001-L",
+                Price = 119.99m,
+                Currency = "USD",
+                StockQuantity = 0,
+                IsActive = false
+            }
+        };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByProductIdAsync(productId, CancellationToken))
+            .ReturnsAsync(variants);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Count.Should().Be(3);
+        
+        var smallVariant = result.Value.First(v => v.Sku == "TP-001-S");
+        smallVariant.Sku.Should().Be("TP-001-S");
+        smallVariant.Price.Should().Be(99.99m);
+        smallVariant.StockQuantity.Should().Be(50);
+        smallVariant.IsActive.Should().BeTrue();
+
+        var largeVariant = result.Value.First(v => v.Sku == "TP-001-L");
+        largeVariant.Sku.Should().Be("TP-001-L");
+        largeVariant.StockQuantity.Should().Be(0);
+        largeVariant.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WithProductWithNoVariants_ReturnsEmptyList()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        var productDto = new ProductDto
+        {
+            Id = productId,
+            Name = "Test Product",
+            IsActive = true
+        };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByProductIdAsync(productId, CancellationToken))
+            .ReturnsAsync(new List<ProductVariantDto>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentProduct_ReturnsNotFoundError()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync((ProductDto)null);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Type.ToString().Should().Be("NotFound");
+        result.Error.Message.Should().Contain($"Product with ID {productId} not found");
+        
+        // Verify that variant repository was not called
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetByProductIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenProductRetrievalThrowsException_ReturnsFailureResult()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariants.GetFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+
+    [Fact]
+    public async Task Handle_WhenVariantRetrievalThrowsException_ReturnsFailureResult()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        var productDto = new ProductDto
+        {
+            Id = productId,
+            Name = "Test Product",
+            IsActive = true
+        };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByProductIdAsync(productId, CancellationToken))
+            .ThrowsAsync(new Exception("Variant query failed"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariants.GetFailed");
+        result.Error.Message.Should().Contain("Variant query failed");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        // Act & Assert - Cache properties are read-only and set during construction
+        query.CacheKey.Should().Be($"product-{productId}-variants");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesRepositoryCallsInCorrectOrder()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var query = new GetProductVariantsQueryV1 { ProductId = productId };
+
+        var productDto = new ProductDto { Id = productId, Name = "Test Product" };
+        var variants = new List<ProductVariantDto>
+        {
+            new ProductVariantDto { Id = Guid.NewGuid(), ProductId = productId }
+        };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(productDto);
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByProductIdAsync(productId, CancellationToken))
+            .ReturnsAsync(variants);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        // Verify both repositories were called with correct parameters
+        Fixture.MockProductReadRepository.Verify(
+            repo => repo.GetByIdAsync(productId, CancellationToken),
+            Times.Once);
+
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetByProductIdAsync(productId, CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductsDatatableQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetProductsDatatableQueryHandlerTests.cs
@@ -1,0 +1,325 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetProductsDatatable.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetProductsDatatableQueryHandlerTests : TestBase
+{
+    private readonly GetProductsDatatableQueryHandlerV1 _handler;
+
+    public GetProductsDatatableQueryHandlerTests()
+    {
+        _handler = new GetProductsDatatableQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetProductsDatatableQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_ReturnsFormattedDatatableResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10,
+            Search = new DataTableSearch { Value = "laptop" },
+            Order = new List<DataTableOrder>
+            {
+                new DataTableOrder { Column = 0, Dir = "asc" }
+            },
+            Columns = new List<DataTableColumn>
+            {
+                new DataTableColumn { Data = "name", Name = "Name", Searchable = true, Orderable = true }
+            }
+        };
+
+        var query = new GetProductsDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var variants = new List<ProductVariantDto>
+        {
+            new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 50 },
+            new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 30 }
+        };
+
+        var categories = new List<CategoryDto>
+        {
+            new CategoryDto { Id = Guid.NewGuid(), Name = "Electronics" },
+            new CategoryDto { Id = Guid.NewGuid(), Name = "Computers" }
+        };
+
+        var productDetails = new List<ProductDetailDto>
+        {
+            new ProductDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Gaming Laptop",
+                Slug = "gaming-laptop",
+                Description = "High-performance gaming laptop",
+                BasePrice = 1299.99m,
+                Currency = "USD",
+                Sku = "GL-001",
+                IsActive = true,
+                Variants = variants,
+                Categories = categories,
+                CreatedAt = DateTime.UtcNow.AddDays(-30),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new ProductDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Business Laptop",
+                Slug = "business-laptop",
+                Description = "Professional business laptop",
+                BasePrice = 899.99m,
+                Currency = "USD",
+                Sku = "BL-001",
+                IsActive = true,
+                Variants = new List<ProductVariantDto>
+                {
+                    new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 25 }
+                },
+                Categories = categories,
+                CreatedAt = DateTime.UtcNow.AddDays(-20),
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        var datatableResult = new DataTableResult<ProductDetailDto>(
+            draw: 1,
+            recordsTotal: 2,
+            recordsFiltered: 2,
+            data: productDetails);
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetProductDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(2);
+        result.Value.RecordsFiltered.Should().Be(2);
+        result.Value.Data.Count.Should().Be(2);
+
+        var firstProduct = result.Value.Data.First();
+        firstProduct.Name.Should().Be("Gaming Laptop");
+        firstProduct.Slug.Should().Be("gaming-laptop");
+        firstProduct.BasePrice.Should().Be(1299.99m);
+        firstProduct.Sku.Should().Be("GL-001");
+        firstProduct.VariantsCount.Should().Be(2);
+        firstProduct.TotalStockQuantity.Should().Be(80);
+        firstProduct.Categories.Count.Should().Be(2);
+        firstProduct.Categories.Should().Contain("Electronics");
+        firstProduct.Categories.Should().Contain("Computers");
+    }
+
+    [Fact]
+    public async Task Handle_WithProductsWithoutVariantsOrCategories_HandlesNullCollections()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetProductsDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var productDetails = new List<ProductDetailDto>
+        {
+            new ProductDetailDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Simple Product",
+                Slug = "simple-product",
+                BasePrice = 49.99m,
+                Currency = "USD",
+                Sku = "SP-001",
+                IsActive = true,
+                Variants = null, // Null variants
+                Categories = null, // Null categories
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        var datatableResult = new DataTableResult<ProductDetailDto>(
+            draw: 1,
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            data: productDetails);
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetProductDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        var product = result.Value.Data.First();
+        product.VariantsCount.Should().Be(0);
+        product.TotalStockQuantity.Should().Be(0);
+        product.Categories.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyResult_ReturnsEmptyDatatableResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetProductsDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var datatableResult = new DataTableResult<ProductDetailDto>(
+            draw: 1,
+            recordsTotal: 0,
+            recordsFiltered: 0,
+            data: new List<ProductDetailDto>());
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetProductDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(0);
+        result.Value.RecordsFiltered.Should().Be(0);
+        result.Value.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetProductsDatatableQueryV1
+        {
+            Request = request
+        };
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetProductDetailDataTableAsync(request, CancellationToken))
+            .ThrowsAsync(new Exception("Test exception"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Products.GetDataTableFailed");
+        result.Error.Message.Should().Contain("Test exception");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCorrectMappingFromProductDetailToDto()
+    {
+        // Arrange
+        var request = new DataTableRequest
+        {
+            Draw = 1,
+            Start = 0,
+            Length = 10
+        };
+
+        var query = new GetProductsDatatableQueryV1
+        {
+            Request = request
+        };
+
+        var sourceProduct = new ProductDetailDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Product",
+            Slug = "test-product",
+            Description = "Test product description",
+            BasePrice = 199.99m,
+            Currency = "EUR",
+            Sku = "TP-123",
+            IsActive = false,
+            Variants = new List<ProductVariantDto>
+            {
+                new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 10 },
+                new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 15 },
+                new ProductVariantDto { Id = Guid.NewGuid(), StockQuantity = 0 }
+            },
+            Categories = new List<CategoryDto>
+            {
+                new CategoryDto { Id = Guid.NewGuid(), Name = "Category 1" },
+                new CategoryDto { Id = Guid.NewGuid(), Name = "Category 2" }
+            },
+            CreatedAt = DateTime.UtcNow.AddDays(-60),
+            UpdatedAt = DateTime.UtcNow.AddDays(-5)
+        };
+
+        var datatableResult = new DataTableResult<ProductDetailDto>(
+            draw: 1,
+            recordsTotal: 1,
+            recordsFiltered: 1,
+            data: new List<ProductDetailDto> { sourceProduct });
+
+        Fixture.MockProductReadRepository
+            .Setup(repo => repo.GetProductDetailDataTableAsync(request, CancellationToken))
+            .ReturnsAsync(datatableResult);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        var mappedProduct = result.Value.Data.First();
+        mappedProduct.Id.Should().Be(sourceProduct.Id);
+        mappedProduct.Name.Should().Be(sourceProduct.Name);
+        mappedProduct.Slug.Should().Be(sourceProduct.Slug);
+        mappedProduct.Description.Should().Be(sourceProduct.Description);
+        mappedProduct.BasePrice.Should().Be(sourceProduct.BasePrice);
+        mappedProduct.Currency.Should().Be(sourceProduct.Currency);
+        mappedProduct.Sku.Should().Be(sourceProduct.Sku);
+        mappedProduct.IsActive.Should().Be(sourceProduct.IsActive);
+        mappedProduct.VariantsCount.Should().Be(3);
+        mappedProduct.TotalStockQuantity.Should().Be(25); // 10 + 15 + 0
+        mappedProduct.Categories.Count.Should().Be(2);
+        mappedProduct.Categories.Should().Contain("Category 1");
+        mappedProduct.Categories.Should().Contain("Category 2");
+        mappedProduct.CreatedAt.Should().Be(sourceProduct.CreatedAt);
+        mappedProduct.UpdatedAt.Should().Be(sourceProduct.UpdatedAt);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetVariantBySkuQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetVariantBySkuQueryHandlerTests.cs
@@ -1,0 +1,202 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetVariantBySku.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetVariantBySkuQueryHandlerTests : TestBase
+{
+    private readonly GetVariantBySkuQueryHandlerV1 _handler;
+
+    public GetVariantBySkuQueryHandlerTests()
+    {
+        _handler = new GetVariantBySkuQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetVariantBySkuQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidSku_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var sku = "LAPTOP-001-16GB";
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        
+        var variantDto = new ProductVariantDto
+        {
+            Id = variantId,
+            ProductId = productId,
+            Sku = sku,
+            Price = 1299.99m,
+            Currency = "USD",
+            StockQuantity = 15,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-10),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1)
+        };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ReturnsAsync(variantDto);
+
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(variantId);
+        result.Value.ProductId.Should().Be(productId);
+        result.Value.Sku.Should().Be(sku);
+        result.Value.Price.Should().Be(1299.99m);
+        result.Value.Currency.Should().Be("USD");
+        result.Value.StockQuantity.Should().Be(15);
+        result.Value.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentSku_ReturnsNotFoundError()
+    {
+        // Arrange
+        var sku = "NON-EXISTENT-SKU";
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ReturnsAsync((ProductVariantDto)null);
+
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Type.ToString().Should().Be("NotFound");
+        result.Error.Message.Should().Contain($"Product variant with SKU {sku} not found");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task Handle_WithInvalidSku_ReturnsValidationError(string invalidSku)
+    {
+        // Arrange
+        var query = new GetVariantBySkuQueryV1 { Sku = invalidSku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Type.ToString().Should().Be("Validation");
+        result.Error.Message.Should().Be("SKU cannot be empty");
+        
+        // Verify repository was not called
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetBySkuAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var sku = "TEST-SKU";
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection timeout"));
+
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.GetBySkuFailed");
+        result.Error.Message.Should().Contain("Database connection timeout");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var sku = "TEST-SKU-001";
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ReturnsAsync(new ProductVariantDto { Id = Guid.NewGuid(), Sku = sku });
+
+        // Act
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        query.CacheKey.Should().Be($"variant-sku-{sku}");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public async Task Handle_WithCaseSensitiveSku_CallsRepositoryWithExactSku()
+    {
+        // Arrange
+        var sku = "MiXeDcAsE-SKU-123";
+        var variantDto = new ProductVariantDto
+        {
+            Id = Guid.NewGuid(),
+            Sku = sku,
+            Currency = "USD"
+        };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ReturnsAsync(variantDto);
+
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Sku.Should().Be(sku);
+        
+        // Verify the exact SKU (with original casing) was passed to repository
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetBySkuAsync(sku, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesRepositoryCalledOnce()
+    {
+        // Arrange
+        var sku = "VERIFY-ONCE-SKU";
+        var variantDto = new ProductVariantDto { Id = Guid.NewGuid(), Sku = sku };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetBySkuAsync(sku, CancellationToken))
+            .ReturnsAsync(variantDto);
+
+        var query = new GetVariantBySkuQueryV1 { Sku = sku };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetBySkuAsync(sku, CancellationToken),
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetVariantQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Catalog/Queries/GetVariantQueryHandlerTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Moq;
+using Shopilent.Application.Features.Catalog.Queries.GetVariant.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Catalog.DTOs;
+using Shopilent.Domain.Common.Results;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Catalog.Queries;
+
+public class GetVariantQueryHandlerTests : TestBase
+{
+    private readonly GetVariantQueryHandlerV1 _handler;
+
+    public GetVariantQueryHandlerTests()
+    {
+        _handler = new GetVariantQueryHandlerV1(
+            Fixture.MockUnitOfWork.Object,
+            Fixture.GetLogger<GetVariantQueryHandlerV1>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidVariantId_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var variantDto = new ProductVariantDto
+        {
+            Id = variantId,
+            ProductId = productId,
+            Sku = "TEST-001-L",
+            Price = 129.99m,
+            Currency = "USD",
+            StockQuantity = 25,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variantDto);
+
+        var query = new GetVariantQueryV1 { Id = variantId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(variantId);
+        result.Value.ProductId.Should().Be(productId);
+        result.Value.Sku.Should().Be("TEST-001-L");
+        result.Value.Price.Should().Be(129.99m);
+        result.Value.Currency.Should().Be("USD");
+        result.Value.StockQuantity.Should().Be(25);
+        result.Value.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidVariantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync((ProductVariantDto)null);
+
+        var query = new GetVariantQueryV1 { Id = variantId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Type.ToString().Should().Be("NotFound");
+        result.Error.Message.Should().Contain($"Product variant with ID {variantId} not found");
+    }
+
+    [Fact]
+    public async Task Handle_WhenExceptionOccurs_ReturnsFailureResult()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        var query = new GetVariantQueryV1 { Id = variantId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("ProductVariant.GetFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesCacheKeyAndExpirationAreSet()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var query = new GetVariantQueryV1 { Id = variantId };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(new ProductVariantDto { Id = variantId, Sku = "TEST-001" });
+
+        // Act
+        await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        query.CacheKey.Should().Be($"variant-{variantId}");
+        query.Expiration.Should().NotBeNull();
+        query.Expiration.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public async Task Handle_VerifiesRepositoryCalledOnce()
+    {
+        // Arrange
+        var variantId = Guid.NewGuid();
+        var query = new GetVariantQueryV1 { Id = variantId };
+
+        var variantDto = new ProductVariantDto { Id = variantId, Sku = "TEST-001" };
+
+        Fixture.MockProductVariantReadRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variantDto);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        Fixture.MockProductVariantReadRepository.Verify(
+            repo => repo.GetByIdAsync(variantId, CancellationToken),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
- Added unit tests for `AddProductVariantCommandHandler`, `CreateAttributeCommandHandler`, and `CreateProductCommandHandler`.
- Covered various scenarios including successful operations, validation errors, and edge cases.
- Utilized `FluentAssertions` for readable and expressive assertions.
- Improved test setup to support dependency injection and MediatR pipeline configuration.