### PR TITLE
Add unit tests for sales command handlers

### DIFF
--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/AddItemToCartCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/AddItemToCartCommandTests.cs
@@ -1,0 +1,332 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.AddItemToCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Catalog;
+using Shopilent.Domain.Catalog.Errors;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class AddItemToCartCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public AddItemToCartCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<AddItemToCartCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<AddItemToCartCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<AddItemToCartCommandV1>, AddItemToCartCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task AddItemToCart_WithValidDataAndExistingCart_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AddItemToCartCommandV1
+        {
+            CartId = cartId,
+            ProductId = productId,
+            Quantity = 2
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var product = new ProductBuilder().WithId(productId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(product);
+            
+        // Capture cart updates
+        Cart updatedCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => updatedCart = c)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.CartId.Should().Be(cartId);
+        result.Value.ProductId.Should().Be(productId);
+        result.Value.Quantity.Should().Be(2);
+        
+        // Verify cart was updated
+        updatedCart.Should().NotBeNull();
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task AddItemToCart_WithNonExistentProduct_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AddItemToCartCommandV1
+        {
+            CartId = cartId,
+            ProductId = productId,
+            Quantity = 1
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        // Product not found
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync((Product)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(ProductErrors.NotFound(productId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task AddItemToCart_WithNonExistentCart_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AddItemToCartCommandV1
+        {
+            CartId = cartId,
+            ProductId = productId,
+            Quantity = 1
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls - cart not found
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(cartId).Code);
+    }
+    
+    [Fact]
+    public async Task AddItemToCart_CreatesNewCartWhenNoneExists_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var productId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AddItemToCartCommandV1
+        {
+            // No cart ID - should create new cart
+            ProductId = productId,
+            Quantity = 1
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var product = new ProductBuilder().WithId(productId).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // No existing cart
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+            
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(product);
+            
+        // Capture new cart being added
+        Cart addedCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => addedCart = c)
+            .ReturnsAsync((Cart c, CancellationToken _) => c);
+            
+        // Mock save changes to return success
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.ProductId.Should().Be(productId);
+        result.Value.Quantity.Should().Be(1);
+        
+        // Verify new cart was created and added
+        addedCart.Should().NotBeNull();
+        addedCart.UserId.Should().Be(userId);
+        
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+        
+        // Verify save was called twice (once for cart creation, once for item addition)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Exactly(2));
+    }
+    
+    [Fact]
+    public async Task AddItemToCart_WithVariant_AddsVariantToCart()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var variantId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AddItemToCartCommandV1
+        {
+            CartId = cartId,
+            ProductId = productId,
+            VariantId = variantId,
+            Quantity = 1
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var product = new ProductBuilder().WithId(productId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Create a variant using the domain factory method
+        var variantResult = ProductVariant.Create(productId, "TEST-VARIANT", null, 10);
+        if (variantResult.IsFailure)
+            throw new InvalidOperationException($"Failed to create variant: {variantResult.Error.Message}");
+        var variant = variantResult.Value;
+        
+        // Set the specific ID we want for testing using reflection (similar to other builders)
+        SetPrivatePropertyValue(variant, "Id", variantId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(productId, CancellationToken))
+            .ReturnsAsync(product);
+            
+        Fixture.MockProductVariantWriteRepository
+            .Setup(repo => repo.GetByIdAsync(variantId, CancellationToken))
+            .ReturnsAsync(variant);
+            
+        // Mock save operations
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Cart>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+            
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+            
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.VariantId.Should().Be(variantId);
+        result.Value.ProductId.Should().Be(productId);
+    }
+    
+    private static void SetPrivatePropertyValue(object obj, string propertyName, object value)
+    {
+        var propertyInfo = obj.GetType().GetProperty(propertyName, 
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        propertyInfo?.SetValue(obj, value);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/AssignCartToUserCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/AssignCartToUserCommandTests.cs
@@ -1,0 +1,304 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.AssignCartToUser.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class AssignCartToUserCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public AssignCartToUserCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<AssignCartToUserCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<AssignCartToUserCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<AssignCartToUserCommandV1>, AssignCartToUserCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_AssignsCartToUserSuccessfully()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).Build(); // Cart without user
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // No existing cart for user
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_ReturnsUnauthorizedError()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        // No authenticated user
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.IsAuthenticated).Returns(false);
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Cart.UserNotAuthenticated");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentCart_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Cart not found
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(cartId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_CartAlreadyAssignedToCurrentUser_ReturnsSuccess()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify save was not called (no changes needed)
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_CartAlreadyAssignedToDifferentUser_ReturnsValidationError()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var otherUser = new UserBuilder().WithId(otherUserId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(otherUser).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Cart.AlreadyAssigned");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentUser_ReturnsUserNotFoundError()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var cart = new CartBuilder().WithId(cartId).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        // User not found
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((User)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UserAlreadyHasCart_ReturnsValidationError()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingCartId = Guid.NewGuid();
+        
+        var command = new AssignCartToUserCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).Build();
+        var existingCart = new CartBuilder().WithId(existingCartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+            
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // User already has a cart
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingCart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Cart.UserAlreadyHasCart");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/CancelOrderCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/CancelOrderCommandTests.cs
@@ -1,0 +1,291 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.CancelOrder.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class CancelOrderCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public CancelOrderCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<CancelOrderCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<CancelOrderCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<CancelOrderCommandV1>, CancelOrderCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestByOrderOwner_CancelsOrderSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var reason = "Customer requested cancellation";
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = reason,
+            CurrentUserId = userId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        // Capture order updates
+        Order updatedOrder = null;
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Callback<Order, CancellationToken>((o, _) => updatedOrder = o)
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.OrderId.Should().Be(orderId);
+        result.Value.Reason.Should().Be(reason);
+        result.Value.Status.Should().Be(OrderStatus.Cancelled);
+        
+        // Verify order was updated
+        updatedOrder.Should().NotBeNull();
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Once);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestByAdmin_CancelsOrderSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var reason = "Administrative cancellation";
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = reason,
+            CurrentUserId = adminId,
+            IsAdmin = true,
+            IsManager = false
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).Build();
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.OrderId.Should().Be(orderId);
+        result.Value.Reason.Should().Be(reason);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Test cancellation",
+            CurrentUserId = userId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        // Order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthorizedUser_ReturnsForbiddenError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Unauthorized cancellation attempt",
+            CurrentUserId = otherUserId, // Different user trying to cancel
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.CancelDenied");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NoCurrentUser_ReturnsForbiddenError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Test cancellation",
+            CurrentUserId = null, // No user context
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.CancelDenied");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ManagerRole_CancelsOrderSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var managerId = Guid.NewGuid();
+        var reason = "Manager cancellation";
+        
+        var command = new CancelOrderCommandV1
+        {
+            OrderId = orderId,
+            Reason = reason,
+            CurrentUserId = managerId,
+            IsAdmin = false,
+            IsManager = true // Manager should be able to cancel
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).Build();
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.OrderId.Should().Be(orderId);
+        result.Value.Reason.Should().Be(reason);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/ClearCartCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/ClearCartCommandTests.cs
@@ -1,0 +1,239 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.ClearCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class ClearCartCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public ClearCartCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ClearCartCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<ClearCartCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<ClearCartCommandV1>, ClearCartCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task ClearCart_WithValidCartId_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new ClearCartCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task ClearCart_WithNonExistentCartId_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new ClearCartCommandV1
+        {
+            CartId = cartId
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls - cart not found
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(cartId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task ClearCart_WithoutCartIdForAuthenticatedUser_ClearsUserCart()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        
+        var command = new ClearCartCommandV1
+        {
+            // No cart ID provided
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify the correct repository method was called
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.GetByUserIdAsync(userId, CancellationToken), 
+            Times.Once);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task ClearCart_WithoutCartIdForAnonymousUser_ReturnsErrorResult()
+    {
+        // Arrange
+        var command = new ClearCartCommandV1
+        {
+            // No cart ID provided and no authenticated user
+        };
+        
+        // Don't set authenticated user
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task ClearCart_AccessingOtherUserCart_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var currentUserId = Guid.NewGuid();
+        var cartOwnerId = Guid.NewGuid(); // Different user
+        
+        var command = new ClearCartCommandV1
+        {
+            CartId = cartId
+        };
+        
+        var cartOwner = new UserBuilder().WithId(cartOwnerId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(cartOwner).Build();
+        
+        // Setup current user (different from cart owner)
+        Fixture.SetAuthenticatedUser(currentUserId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(cartId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task ClearCart_WithNoUserCartFound_ReturnsErrorResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var command = new ClearCartCommandV1
+        {
+            // No cart ID provided
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls - no cart found for user
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/CreateCartCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/CreateCartCommandTests.cs
@@ -1,0 +1,282 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.CreateCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Identity;
+using Shopilent.Domain.Identity.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class CreateCartCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public CreateCartCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<CreateCartCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<CreateCartCommandV1>, CreateCartCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_AnonymousUser_CreatesAnonymousCartSuccessfully()
+    {
+        // Arrange
+        var command = new CreateCartCommandV1();
+        
+        // No authenticated user
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Setup cart creation
+        Cart createdCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => createdCart = c)
+            .ReturnsAsync((Cart c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.UserId.Should().BeNull(); // Anonymous cart
+        result.Value.ItemCount.Should().Be(0);
+        createdCart.Should().NotBeNull();
+        
+        // Verify cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithoutExistingCart_CreatesNewCartSuccessfully()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new CreateCartCommandV1();
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // No existing cart
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+            
+        // Setup cart creation
+        Cart createdCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => createdCart = c)
+            .ReturnsAsync((Cart c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.UserId.Should().Be(userId);
+        result.Value.ItemCount.Should().Be(0);
+        createdCart.Should().NotBeNull();
+        createdCart.UserId.Should().Be(userId);
+        
+        // Verify cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithExistingCart_ReturnsExistingCart()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var existingCartId = Guid.NewGuid();
+        var command = new CreateCartCommandV1();
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var existingCart = new CartBuilder().WithId(existingCartId).WithUser(user).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // Existing cart found
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(existingCart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(existingCartId);
+        result.Value.UserId.Should().Be(userId);
+        
+        // Verify no new cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentUser_ReturnsUserNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var command = new CreateCartCommandV1();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // User not found
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((User)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+        
+        // Verify no cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_WithMetadata_CreatesCartWithMetadataSuccessfully()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var metadata = new Dictionary<string, object>
+        {
+            ["source"] = "mobile_app",
+            ["campaign"] = "summer_sale"
+        };
+        
+        var command = new CreateCartCommandV1
+        {
+            Metadata = metadata
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // No existing cart
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+            
+        // Setup cart creation
+        Cart createdCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => createdCart = c)
+            .ReturnsAsync((Cart c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.UserId.Should().Be(userId);
+        result.Value.Metadata.Should().NotBeNull();
+        result.Value.Metadata.Count.Should().Be(2);
+        result.Value.Metadata["source"].Should().Be("mobile_app");
+        result.Value.Metadata["campaign"].Should().Be("summer_sale");
+        
+        // Verify cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_AnonymousUserWithMetadata_CreatesAnonymousCartWithMetadataSuccessfully()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>
+        {
+            ["session"] = "guest_session_123",
+            ["referrer"] = "google_ads"
+        };
+        
+        var command = new CreateCartCommandV1
+        {
+            Metadata = metadata
+        };
+        
+        // No authenticated user
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Setup cart creation
+        Cart createdCart = null;
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken))
+            .Callback<Cart, CancellationToken>((c, _) => createdCart = c)
+            .ReturnsAsync((Cart c, CancellationToken _) => c);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.UserId.Should().BeNull(); // Anonymous cart
+        result.Value.Metadata.Should().NotBeNull();
+        result.Value.Metadata.Count.Should().Be(2);
+        result.Value.Metadata["session"].Should().Be("guest_session_123");
+        result.Value.Metadata["referrer"].Should().Be("google_ads");
+        
+        // Verify cart was added
+        Fixture.MockCartWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Cart>(), CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/CreateOrderFromCartCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/CreateOrderFromCartCommandTests.cs
@@ -1,0 +1,283 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.CreateOrderFromCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Shipping;
+using Shopilent.Domain.Shipping.DTOs;
+using Shopilent.Domain.Shipping.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class CreateOrderFromCartCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public CreateOrderFromCartCommandTests()
+    {
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<CreateOrderFromCartCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblyContaining<CreateOrderFromCartCommandV1>();
+        });
+
+        // Register validator
+        services
+            .AddTransient<FluentValidation.IValidator<CreateOrderFromCartCommandV1>,
+                CreateOrderFromCartCommandValidatorV1>();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task CreateOrderFromCart_WithValidData_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var shippingAddressId = Guid.NewGuid();
+        var billingAddressId = Guid.NewGuid();
+
+        var command = new CreateOrderFromCartCommandV1
+        {
+            CartId = cartId,
+            ShippingAddressId = shippingAddressId,
+            BillingAddressId = billingAddressId,
+            ShippingMethod = "Standard"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+
+        // Add a test item to the cart so it's not empty
+        var testProduct = new ProductBuilder().Build();
+        var addItemResult = cart.AddItem(testProduct, 1);
+        if (addItemResult.IsFailure)
+            throw new InvalidOperationException($"Failed to add item to cart: {addItemResult.Error.Message}");
+
+        var shippingAddress = new AddressBuilder()
+            .WithId(shippingAddressId)
+            .WithUser(user)
+            .WithAddressType(AddressType.Shipping)
+            .WithStreetAddress("123 Main St")
+            .WithLocation("Anytown", "CA", "12345", "US")
+            .Build();
+
+        var billingAddress = new AddressBuilder()
+            .WithId(billingAddressId)
+            .WithUser(user)
+            .WithAddressType(AddressType.Billing)
+            .WithStreetAddress("123 Main St")
+            .WithLocation("Anytown", "CA", "12345", "US")
+            .Build();
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock user repository - user exists
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+
+        Fixture.MockAddressWriteRepository
+            .Setup(repo => repo.GetByIdAsync(shippingAddressId, CancellationToken))
+            .ReturnsAsync(shippingAddress);
+
+        Fixture.MockAddressWriteRepository
+            .Setup(repo => repo.GetByIdAsync(billingAddressId, CancellationToken))
+            .ReturnsAsync(billingAddress);
+
+        Fixture.MockProductWriteRepository
+            .Setup(repo => repo.GetByIdAsync(testProduct.Id, CancellationToken))
+            .ReturnsAsync(testProduct);
+
+        // Capture order being added
+        Order addedOrder = null;
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.AddAsync(It.IsAny<Order>(), CancellationToken))
+            .Callback<Order, CancellationToken>((o, _) => addedOrder = o)
+            .ReturnsAsync((Order o, CancellationToken _) => o);
+
+        // Mock save operations
+        Fixture.MockUnitOfWork
+            .Setup(uow => uow.SaveChangesAsync(CancellationToken))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.UserId.Should().Be(userId);
+        result.Value.ShippingAddressId.Should().Be(shippingAddressId);
+        result.Value.BillingAddressId.Should().Be(billingAddressId);
+        result.Value.ShippingMethod.Should().Be("Standard");
+
+        // Verify order was created and added
+        addedOrder.Should().NotBeNull();
+        addedOrder.UserId.Should().Be(userId);
+
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Once);
+
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateOrderFromCart_WithNonExistentCart_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new CreateOrderFromCartCommandV1
+        {
+            CartId = cartId, ShippingAddressId = Guid.NewGuid(), BillingAddressId = Guid.NewGuid()
+        };
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock user repository - user exists
+        var user = new UserBuilder().WithId(userId).Build();
+        Fixture.MockUserWriteRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+
+        // Mock repository calls - cart not found
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(cartId).Code);
+
+        // Verify order was not created
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateOrderFromCart_WithNonExistentShippingAddress_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var shippingAddressId = Guid.NewGuid();
+        var billingAddressId = Guid.NewGuid();
+
+        var command = new CreateOrderFromCartCommandV1
+        {
+            CartId = cartId, ShippingAddressId = shippingAddressId, BillingAddressId = billingAddressId
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        var billingAddressDto = new AddressDto
+        {
+            Id = billingAddressId,
+            UserId = userId,
+            AddressLine1 = "123 Main St",
+            City = "Anytown",
+            State = "CA",
+            PostalCode = "12345",
+            Country = "US",
+            AddressType = AddressType.Billing,
+            IsDefault = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+
+        // Shipping address not found
+        Fixture.MockAddressReadRepository
+            .Setup(repo => repo.GetByIdAsync(shippingAddressId, CancellationToken))
+            .ReturnsAsync((AddressDto)null);
+
+        Fixture.MockAddressReadRepository
+            .Setup(repo => repo.GetByIdAsync(billingAddressId, CancellationToken))
+            .ReturnsAsync(billingAddressDto);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+
+        // Verify order was not created
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateOrderFromCart_AccessingOtherUserCart_ReturnsErrorResult()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var currentUserId = Guid.NewGuid();
+        var cartOwnerId = Guid.NewGuid(); // Different user
+
+        var command = new CreateOrderFromCartCommandV1
+        {
+            CartId = cartId, ShippingAddressId = Guid.NewGuid(), BillingAddressId = Guid.NewGuid()
+        };
+
+        var cartOwner = new UserBuilder().WithId(cartOwnerId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(cartOwner).Build();
+
+        // Setup current user (different from cart owner)
+        Fixture.SetAuthenticatedUser(currentUserId);
+
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cart);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+
+        // Verify order was not created
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.AddAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/MarkOrderAsDeliveredCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/MarkOrderAsDeliveredCommandTests.cs
@@ -1,0 +1,259 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.MarkOrderAsDelivered.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class MarkOrderAsDeliveredCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public MarkOrderAsDeliveredCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<MarkOrderAsDeliveredCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<MarkOrderAsDeliveredCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<MarkOrderAsDeliveredCommandV1>, MarkOrderAsDeliveredCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidShippedOrder_MarksAsDeliveredSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Shipped).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(OrderStatus.Delivered);
+        result.Value.Message.Should().Be("Order marked as delivered successfully");
+        result.Value.UpdatedAt.Should().BeBefore(DateTime.UtcNow.AddSeconds(1));
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_OrderNotInShippedStatus_ReturnsFailure()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The actual error will depend on the domain logic implementation
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_OrderAlreadyDelivered_ReturnsSuccessWithoutChanges()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Delivered).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Status.Should().Be(OrderStatus.Delivered);
+        
+        // Verify save was called even though no changes were needed
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithoutAuthenticatedUser_MarksAsDeliveredSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Shipped).Build();
+        
+        // No authenticated user (system process)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(OrderStatus.Delivered);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_CancelledOrder_ReturnsFailure()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new MarkOrderAsDeliveredCommandV1
+        {
+            OrderId = orderId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Cancelled).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The actual error will depend on the domain logic implementation
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/MarkOrderAsShippedCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/MarkOrderAsShippedCommandTests.cs
@@ -1,0 +1,335 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.MarkOrderAsShipped.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Sales.Enums;
+using Shopilent.Domain.Payments.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class MarkOrderAsShippedCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public MarkOrderAsShippedCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<MarkOrderAsShippedCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<MarkOrderAsShippedCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<MarkOrderAsShippedCommandV1>, MarkOrderAsShippedCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidConfirmedOrder_MarksAsShippedSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).WithPaymentStatus(PaymentStatus.Succeeded).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify order was updated and saved
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Once);
+        
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+        
+        // Verify update and save were not called
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Never);
+        
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_OrderWithPaymentNotSucceeded_ReturnsPaymentRequiredError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).WithPaymentStatus(PaymentStatus.Pending).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // Payment must be succeeded before shipping
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_OrderAlreadyShipped_ReturnsSuccessWithoutChanges()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Shipped).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify update and save were called
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Once);
+        
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithoutAuthenticatedUser_MarksAsShippedSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).WithPaymentStatus(PaymentStatus.Succeeded).Build();
+        
+        // No authenticated user (system process)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify order was updated and saved
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Once);
+        
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_CancelledOrder_ReturnsFailure()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = "TRACK123456789";
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Cancelled).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The actual error will depend on the domain logic implementation
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_WithEmptyTrackingNumber_MarksAsShippedSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var trackingNumber = ""; // Empty but valid according to validation
+        
+        var command = new MarkOrderAsShippedCommandV1
+        {
+            OrderId = orderId,
+            TrackingNumber = trackingNumber
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).WithPaymentStatus(PaymentStatus.Succeeded).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+            
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Returns(Task.CompletedTask);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify order was updated and saved
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken), 
+            Times.Once);
+        
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/ProcessOrderPartialRefundCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/ProcessOrderPartialRefundCommandTests.cs
@@ -1,0 +1,333 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.ProcessOrderPartialRefund.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Payments.Enums;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Enums;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class ProcessOrderPartialRefundCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ProcessOrderPartialRefundCommandTests()
+    {
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ProcessOrderPartialRefundCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<ProcessOrderPartialRefundCommandV1>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidPartialRefund_ReturnsSuccess()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var refundAmount = 50.00m;
+        var refundReason = "Damaged item";
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = refundAmount,
+            Currency = "USD",
+            Reason = refundReason
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Shipped)
+            .WithPaymentStatus(PaymentStatus.Succeeded)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Capture order updates
+        Order updatedOrder = null;
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Callback<Order, CancellationToken>((o, _) => updatedOrder = o)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.OrderId.Should().Be(orderId);
+        result.Value.RefundAmount.Should().Be(refundAmount);
+        result.Value.Currency.Should().Be("USD");
+        result.Value.Reason.Should().Be(refundReason);
+        result.Value.IsFullyRefunded.Should().BeFalse(); // Partial refund
+
+        // Verify order was updated
+        updatedOrder.Should().NotBeNull();
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Once);
+
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = 50.00m,
+            Currency = "USD",
+            Reason = "Damaged item"
+        };
+
+        // Mock repository calls - order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidAmount_ReturnsValidationError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = -10.00m, // Invalid negative amount
+            Currency = "USD",
+            Reason = "Test refund"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Shipped)
+            .WithPaymentStatus(PaymentStatus.Succeeded)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // Should fail during Money.Create validation
+
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RefundAmountExceedsOrderTotal_ReturnsBusinessLogicError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var refundAmount = 200.00m; // Exceeds order total of 115.00
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = refundAmount,
+            Currency = "USD",
+            Reason = "Refund exceeds total"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Shipped)
+            .WithPaymentStatus(PaymentStatus.Succeeded)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD") // Total: 115.00
+            .Build();
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The error should be from the domain logic that prevents refunding more than the total
+
+        // Verify save was not called since refund failed
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_OrderNotInRefundableState_ReturnsBusinessLogicError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = 50.00m,
+            Currency = "USD",
+            Reason = "Customer requested refund"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        // Create order in pending status - cannot be refunded
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Pending)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The error should be from the domain logic that prevents refunding pending orders
+
+        // Verify save was not called since refund failed
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_FullRefundThroughPartialRefund_MarksAsFullyRefunded()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var refundAmount = 115.00m; // Full order total
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = refundAmount,
+            Currency = "USD",
+            Reason = "Full refund via partial"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Shipped)
+            .WithPaymentStatus(PaymentStatus.Succeeded)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD") // Total: 115.00
+            .Build();
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Capture order updates
+        Order updatedOrder = null;
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Callback<Order, CancellationToken>((o, _) => updatedOrder = o)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.RefundAmount.Should().Be(refundAmount);
+        result.Value.IsFullyRefunded.Should().BeTrue();
+        result.Value.RemainingAmount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseException_ReturnsFailureResult()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+
+        var command = new ProcessOrderPartialRefundCommandV1
+        {
+            OrderId = orderId,
+            Amount = 50.00m,
+            Currency = "USD",
+            Reason = "Test refund"
+        };
+
+        // Mock repository calls to throw exception
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.PartialRefundFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/ProcessOrderRefundCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/ProcessOrderRefundCommandTests.cs
@@ -1,0 +1,250 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.ProcessOrderRefund.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Payments.Enums;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Enums;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class ProcessOrderRefundCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public ProcessOrderRefundCommandTests()
+    {
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<ProcessOrderRefundCommandHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<ProcessOrderRefundCommandV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<ProcessOrderRefundCommandV1>, ProcessOrderRefundCommandValidatorV1>();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var refundReason = "Customer requested refund";
+
+        var command = new ProcessOrderRefundCommandV1
+        {
+            OrderId = orderId,
+            Reason = refundReason
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Shipped)
+            .WithPaymentStatus(PaymentStatus.Succeeded)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Capture order updates
+        Order updatedOrder = null;
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken))
+            .Callback<Order, CancellationToken>((o, _) => updatedOrder = o)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.OrderId.Should().Be(orderId);
+        result.Value.Reason.Should().Be(refundReason);
+        result.Value.Status.Should().Be("Refunded");
+        result.Value.Currency.Should().Be("USD");
+
+        // Verify order was updated
+        updatedOrder.Should().NotBeNull();
+        Fixture.MockOrderWriteRepository.Verify(
+            repo => repo.UpdateAsync(It.IsAny<Order>(), CancellationToken),
+            Times.Once);
+
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderRefundCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Customer requested refund"
+        };
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls - order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_OrderCannotBeRefunded_ReturnsBusinessLogicError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderRefundCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Customer requested refund"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        // Create order in pending status - cannot be refunded
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Pending)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The error should be from the domain logic that prevents refunding pending orders
+
+        // Verify save was not called since refund failed
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_OrderAlreadyRefunded_ReturnsBusinessLogicError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderRefundCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Customer requested refund"
+        };
+
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder()
+            .WithId(orderId)
+            .WithUser(user)
+            .WithStatus(OrderStatus.Cancelled)
+            .WithPricing(100.00m, 10.00m, 5.00m, "USD")
+            .Build();
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        // The error should be from the domain logic that prevents double refunding
+
+        // Verify save was not called since refund failed
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseException_ReturnsFailureResult()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var command = new ProcessOrderRefundCommandV1
+        {
+            OrderId = orderId,
+            Reason = "Customer requested refund"
+        };
+
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+
+        // Mock repository calls to throw exception
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("OrderRefund.ProcessingFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/RemoveItemFromCartCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/RemoveItemFromCartCommandTests.cs
@@ -1,0 +1,249 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.RemoveItemFromCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class RemoveItemFromCartCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public RemoveItemFromCartCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<RemoveItemFromCartCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<RemoveItemFromCartCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<RemoveItemFromCartCommandV1>, RemoveItemFromCartCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithAuthenticatedUser_RemovesItemSuccessfully()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        
+        var command = new RemoveItemFromCartCommandV1
+        {
+            ItemId = itemId
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can remove it
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to remove
+        SetPrivatePropertyValue(cartItem, "Id", itemId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(itemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithAnonymousUser_RemovesItemSuccessfully()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        
+        var command = new RemoveItemFromCartCommandV1
+        {
+            ItemId = itemId
+        };
+        
+        var cart = new CartBuilder().WithId(cartId).Build(); // Anonymous cart
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can remove it
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to remove
+        SetPrivatePropertyValue(cartItem, "Id", itemId);
+        
+        // No authenticated user
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(itemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ItemNotInAnyCart_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        
+        var command = new RemoveItemFromCartCommandV1
+        {
+            ItemId = itemId
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // No cart found for this item
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(itemId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_CartBelongsToDifferentUser_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        
+        var command = new RemoveItemFromCartCommandV1
+        {
+            ItemId = itemId
+        };
+        
+        var otherUser = new UserBuilder().WithId(otherUserId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(otherUser).Build();
+        
+        // Setup authenticated user (different from cart owner)
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(itemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_AuthenticatedUserAccessingAnonymousCart_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        
+        var command = new RemoveItemFromCartCommandV1
+        {
+            ItemId = itemId
+        };
+        
+        var cart = new CartBuilder().WithId(cartId).Build(); // Anonymous cart (no user)
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can remove it
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to remove
+        SetPrivatePropertyValue(cartItem, "Id", itemId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(itemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    private static void SetPrivatePropertyValue<T>(object obj, string propertyName, T value)
+    {
+        var propertyInfo = obj.GetType().GetProperty(propertyName, 
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        propertyInfo?.SetValue(obj, value);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/UpdateCartItemQuantityCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/UpdateCartItemQuantityCommandTests.cs
@@ -1,0 +1,314 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.UpdateCartItemQuantity.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class UpdateCartItemQuantityCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public UpdateCartItemQuantityCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateCartItemQuantityCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateCartItemQuantityCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateCartItemQuantityCommandV1>, UpdateCartItemQuantityCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithAuthenticatedUser_UpdatesQuantitySuccessfully()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        var newQuantity = 5;
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = newQuantity
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can update its quantity
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to update
+        SetPrivatePropertyValue(cartItem, "Id", cartItemId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.CartItemId.Should().Be(cartItemId);
+        result.Value.Quantity.Should().Be(newQuantity);
+        result.Value.UpdatedAt.Should().BeBefore(DateTime.UtcNow.AddSeconds(1));
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithAnonymousUser_UpdatesQuantitySuccessfully()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        var newQuantity = 3;
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = newQuantity
+        };
+        
+        var cart = new CartBuilder().WithId(cartId).Build(); // Anonymous cart
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can update its quantity
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to update
+        SetPrivatePropertyValue(cartItem, "Id", cartItemId);
+        
+        // No authenticated user
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.CartItemId.Should().Be(cartItemId);
+        result.Value.Quantity.Should().Be(newQuantity);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ItemNotInAnyCart_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = 2
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // No cart found for this item
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync((Cart)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_CartBelongsToDifferentUser_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = 4
+        };
+        
+        var otherUser = new UserBuilder().WithId(otherUserId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(otherUser).Build();
+        
+        // Setup authenticated user (different from cart owner)
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ZeroQuantity_UpdatesQuantitySuccessfully()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        var zeroQuantity = 0;
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = zeroQuantity
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var cart = new CartBuilder().WithId(cartId).WithUser(user).Build();
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can update its quantity
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to update
+        SetPrivatePropertyValue(cartItem, "Id", cartItemId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.CartItemId.Should().Be(cartItemId);
+        result.Value.Quantity.Should().Be(zeroQuantity);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_AuthenticatedUserAccessingAnonymousCart_ReturnsCartNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        var cartItemId = Guid.NewGuid();
+        var newQuantity = 7;
+        
+        var command = new UpdateCartItemQuantityCommandV1
+        {
+            CartItemId = cartItemId,
+            Quantity = newQuantity
+        };
+        
+        var cart = new CartBuilder().WithId(cartId).Build(); // Anonymous cart (no user)
+        var product = new ProductBuilder().Build();
+        
+        // Add an item to the cart so we can update its quantity
+        var addItemResult = cart.AddItem(product, 1);
+        addItemResult.IsSuccess.Should().BeTrue("Failed to add item to cart for test setup");
+        var cartItem = addItemResult.Value;
+        
+        // Use reflection to set the item ID to match what we're trying to update
+        SetPrivatePropertyValue(cartItem, "Id", cartItemId);
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartWriteRepository
+            .Setup(repo => repo.GetCartByItemIdAsync(cartItemId, CancellationToken))
+            .ReturnsAsync(cart);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(CartErrors.CartNotFound(Guid.Empty).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    private static void SetPrivatePropertyValue<T>(object obj, string propertyName, T value)
+    {
+        var propertyInfo = obj.GetType().GetProperty(propertyName, 
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        propertyInfo?.SetValue(obj, value);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Commands/UpdateOrderStatusCommandTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Commands/UpdateOrderStatusCommandTests.cs
@@ -1,0 +1,346 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Commands.UpdateOrderStatus.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Sales;
+using Shopilent.Domain.Sales.Errors;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Commands;
+
+public class UpdateOrderStatusCommandTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public UpdateOrderStatusCommandTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<UpdateOrderStatusCommandHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<UpdateOrderStatusCommandV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<UpdateOrderStatusCommandV1>, UpdateOrderStatusCommandValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidStatusTransition_UpdatesStatusSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var reason = "Order approved for processing";
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Processing,
+            Reason = reason
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(OrderStatus.Processing);
+        result.Value.UpdatedAt.Should().BeBefore(DateTime.UtcNow.AddSeconds(1));
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Processing
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Order not found
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((Order)null);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_InvalidStatusTransition_ReturnsValidationError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Delivered // Invalid: Cannot go from Pending to Delivered directly
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Message.Should().Contain("Cannot transition from Pending to Delivered");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_SameStatusUpdate_ReturnsValidationError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Pending // Same as current status
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Pending).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Message.Should().Contain("Order is already Pending");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_TransitionFromDeliveredStatus_ReturnsValidationError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Cancelled // Cannot cancel delivered order
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Delivered).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Message.Should().Contain("Cannot transition from Delivered to Cancelled");
+        
+        // Verify save was not called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidCancellationFromProcessing_UpdatesStatusSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var reason = "Customer requested cancellation";
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Cancelled,
+            Reason = reason
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(OrderStatus.Cancelled);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestWithoutAuthenticatedUser_UpdatesStatusSuccessfully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = OrderStatus.Shipped
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(OrderStatus.Processing).Build();
+        
+        // No authenticated user (system process)
+        Fixture.MockCurrentUserContext.Setup(ctx => ctx.UserId).Returns((Guid?)null);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(OrderStatus.Shipped);
+        
+        // Verify save was called
+        Fixture.MockUnitOfWork.Verify(
+            uow => uow.SaveChangesAsync(CancellationToken), 
+            Times.Once);
+    }
+    
+    [Theory]
+    [InlineData(OrderStatus.Pending, OrderStatus.Processing)]
+    [InlineData(OrderStatus.Pending, OrderStatus.Cancelled)]
+    [InlineData(OrderStatus.Processing, OrderStatus.Shipped)]
+    [InlineData(OrderStatus.Processing, OrderStatus.Cancelled)]
+    [InlineData(OrderStatus.Shipped, OrderStatus.Delivered)]
+    [InlineData(OrderStatus.Shipped, OrderStatus.Cancelled)]
+    public async Task Handle_ValidStatusTransitions_UpdatesStatusSuccessfully(OrderStatus fromStatus, OrderStatus toStatus)
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var command = new UpdateOrderStatusCommandV1
+        {
+            Id = orderId,
+            Status = toStatus
+        };
+        
+        var user = new UserBuilder().WithId(userId).Build();
+        var order = new OrderBuilder().WithId(orderId).WithUser(user).WithStatus(fromStatus).Build();
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockOrderWriteRepository
+            .Setup(repo => repo.GetByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(order);
+        
+        // Act
+        var result = await _mediator.Send(command, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.Status.Should().Be(toStatus);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Queries/GetCartQueryTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Queries/GetCartQueryTests.cs
@@ -1,0 +1,270 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Queries.GetCart.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Sales.DTOs;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Queries;
+
+public class GetCartQueryTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public GetCartQueryTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.MockCurrentUserContext.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetCartQueryHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetCartQueryV1>();
+        });
+        
+        // Register validator if it exists
+        // services.AddTransient<FluentValidation.IValidator<GetCartQueryV1>, GetCartQueryValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task GetCart_WithValidCartId_ReturnsCart()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetCartQueryV1
+        {
+            CartId = cartId
+        };
+        
+        var cartDto = new CartDto
+        {
+            Id = cartId,
+            UserId = userId,
+            TotalItems = 2,
+            TotalAmount = 99.99m,
+            Items = new List<CartItemDto>(),
+            Metadata = new Dictionary<string, object>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartReadRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cartDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(cartId);
+        result.Value.UserId.Should().Be(userId);
+        result.Value.TotalItems.Should().Be(2);
+        result.Value.TotalAmount.Should().Be(99.99m);
+        
+        // Verify repository was called correctly
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByIdAsync(cartId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetCart_WithoutCartIdForAuthenticatedUser_ReturnsUserCart()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var cartId = Guid.NewGuid();
+        
+        var query = new GetCartQueryV1
+        {
+            // No cart ID provided
+        };
+        
+        var cartDto = new CartDto
+        {
+            Id = cartId,
+            UserId = userId,
+            TotalItems = 1,
+            TotalAmount = 49.99m,
+            Items = new List<CartItemDto>(),
+            Metadata = new Dictionary<string, object>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls
+        Fixture.MockCartReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(cartDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(cartId);
+        result.Value.UserId.Should().Be(userId);
+        
+        // Verify the correct repository method was called
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(userId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetCart_WithNonExistentCartId_ReturnsNull()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetCartQueryV1
+        {
+            CartId = cartId
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls - cart not found
+        Fixture.MockCartReadRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync((CartDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+        
+        // Verify repository was called correctly
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByIdAsync(cartId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetCart_AccessingOtherUserCart_ReturnsNull()
+    {
+        // Arrange
+        var cartId = Guid.NewGuid();
+        var currentUserId = Guid.NewGuid();
+        var cartOwnerId = Guid.NewGuid(); // Different user
+        
+        var query = new GetCartQueryV1
+        {
+            CartId = cartId
+        };
+        
+        var cartDto = new CartDto
+        {
+            Id = cartId,
+            UserId = cartOwnerId, // Cart belongs to different user
+            TotalItems = 1,
+            TotalAmount = 49.99m,
+            Items = new List<CartItemDto>(),
+            Metadata = new Dictionary<string, object>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Setup current user (different from cart owner)
+        Fixture.SetAuthenticatedUser(currentUserId);
+        
+        // Mock repository calls
+        Fixture.MockCartReadRepository
+            .Setup(repo => repo.GetByIdAsync(cartId, CancellationToken))
+            .ReturnsAsync(cartDto);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull(); // Should return null for security reasons
+        
+        // Verify repository was called correctly
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByIdAsync(cartId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task GetCart_ForAnonymousUserWithoutCartId_ReturnsNull()
+    {
+        // Arrange
+        var query = new GetCartQueryV1
+        {
+            // No cart ID and no authenticated user
+        };
+        
+        // Don't set authenticated user
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+        
+        // Verify no repository calls were made
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), 
+            Times.Never);
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task GetCart_WithNoUserCartFound_ReturnsNull()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetCartQueryV1
+        {
+            // No cart ID provided
+        };
+        
+        // Setup authenticated user
+        Fixture.SetAuthenticatedUser(userId);
+        
+        // Mock repository calls - no cart found for user
+        Fixture.MockCartReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync((CartDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+        
+        // Verify repository was called correctly
+        Fixture.MockCartReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(userId, CancellationToken), 
+            Times.Once);
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Queries/GetOrderDetailsQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Queries/GetOrderDetailsQueryHandlerTests.cs
@@ -1,0 +1,342 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Queries.GetOrderDetails.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Common.Errors;
+using Shopilent.Domain.Sales.DTOs;
+using Shopilent.Domain.Sales.Enums;
+using Shopilent.Domain.Sales.Errors;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Queries;
+
+public class GetOrderDetailsQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public GetOrderDetailsQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetOrderDetailsQueryHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetOrderDetailsQueryV1>();
+        });
+        
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<GetOrderDetailsQueryV1>, GetOrderDetailsQueryValidatorV1>();
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestAsOwner_ReturnsOrderDetails()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = userId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var orderDetails = new OrderDetailDto
+        {
+            Id = orderId,
+            UserId = userId,
+            Status = OrderStatus.Delivered,
+            Total = 115.00m,
+            Currency = "USD",
+            Items = new List<OrderItemDto>
+            {
+                new OrderItemDto
+                {
+                    Id = Guid.NewGuid(),
+                    ProductId = Guid.NewGuid(),
+                    Quantity = 2,
+                    UnitPrice = 50.00m,
+                    TotalPrice = 100.00m
+                }
+            },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetails);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.UserId.Should().Be(userId);
+        result.Value.Total.Should().Be(115.00m);
+        result.Value.Status.Should().Be(OrderStatus.Delivered);
+        
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(orderId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestAsAdmin_ReturnsOrderDetails()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var adminUserId = Guid.NewGuid();
+        var orderOwnerUserId = Guid.NewGuid(); // Different user
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = adminUserId,
+            IsAdmin = true,
+            IsManager = false
+        };
+        
+        var orderDetails = new OrderDetailDto
+        {
+            Id = orderId,
+            UserId = orderOwnerUserId, // Order belongs to different user
+            Status = OrderStatus.Pending,
+            Total = 75.00m,
+            Currency = "USD",
+            Items = new List<OrderItemDto>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetails);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.UserId.Should().Be(orderOwnerUserId);
+        
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(orderId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequestAsManager_ReturnsOrderDetails()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var managerUserId = Guid.NewGuid();
+        var orderOwnerUserId = Guid.NewGuid(); // Different user
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = managerUserId,
+            IsAdmin = false,
+            IsManager = true
+        };
+        
+        var orderDetails = new OrderDetailDto
+        {
+            Id = orderId,
+            UserId = orderOwnerUserId, // Order belongs to different user
+            Status = OrderStatus.Shipped,
+            Total = 200.00m,
+            Currency = "USD",
+            Items = new List<OrderItemDto>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetails);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be(orderId);
+        result.Value.UserId.Should().Be(orderOwnerUserId);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentOrder_ReturnsNotFoundError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = userId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        // Mock repository calls - order not found
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((OrderDetailDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(OrderErrors.NotFound(orderId).Code);
+        
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(orderId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthorizedUserAccessingOtherUserOrder_ReturnsForbiddenError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var currentUserId = Guid.NewGuid();
+        var orderOwnerUserId = Guid.NewGuid(); // Different user
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = currentUserId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var orderDetails = new OrderDetailDto
+        {
+            Id = orderId,
+            UserId = orderOwnerUserId, // Order belongs to different user
+            Status = OrderStatus.Pending,
+            Total = 50.00m,
+            Currency = "USD",
+            Items = new List<OrderItemDto>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetails);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.AccessDenied");
+        result.Error.Message.Should().Be("You are not authorized to view this order");
+        
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(orderId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_ReturnsForbiddenError()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var orderOwnerUserId = Guid.NewGuid();
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = null, // Unauthenticated
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        var orderDetails = new OrderDetailDto
+        {
+            Id = orderId,
+            UserId = orderOwnerUserId,
+            Status = OrderStatus.Pending,
+            Total = 50.00m,
+            Currency = "USD",
+            Items = new List<OrderItemDto>(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetails);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.AccessDenied");
+        
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetDetailByIdAsync(orderId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_DatabaseException_ReturnsFailureResult()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetOrderDetailsQueryV1
+        {
+            OrderId = orderId,
+            CurrentUserId = userId,
+            IsAdmin = false,
+            IsManager = false
+        };
+        
+        // Mock repository calls to throw exception
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Order.GetDetailsFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Queries/GetOrdersDatatableQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Queries/GetOrdersDatatableQueryHandlerTests.cs
@@ -1,0 +1,400 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Queries.GetOrdersDatatable.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Common.Models;
+using Shopilent.Domain.Identity.DTOs;
+using Shopilent.Domain.Payments.Enums;
+using Shopilent.Domain.Sales.DTOs;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Queries;
+
+public class GetOrdersDatatableQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public GetOrdersDatatableQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetOrdersDatatableQueryHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetOrdersDatatableQueryV1>();
+        });
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsDataTableResult()
+    {
+        // Arrange
+        var userId1 = Guid.NewGuid();
+        var userId2 = Guid.NewGuid();
+        var order1Id = Guid.NewGuid();
+        var order2Id = Guid.NewGuid();
+        
+        var query = new GetOrdersDatatableQueryV1
+        {
+            Request = new DataTableRequest
+            {
+                Draw = 1,
+                Start = 0,
+                Length = 10,
+                Search = new DataTableSearch { Value = "" },
+                Order = new List<DataTableOrder>(),
+                Columns = new List<DataTableColumn>()
+            }
+        };
+        
+        // Mock order data
+        var mockOrders = new List<OrderDetailDto>
+        {
+            new OrderDetailDto
+            {
+                Id = order1Id,
+                UserId = userId1,
+                Subtotal = 100.00m,
+                Tax = 10.00m,
+                ShippingCost = 5.00m,
+                Total = 115.00m,
+                Currency = "USD",
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Standard",
+                TrackingNumber = "TRACK-001",
+                RefundedAmount = 0,
+                RefundedAt = null,
+                RefundReason = null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Items = new List<OrderItemDto>()
+            },
+            new OrderDetailDto
+            {
+                Id = order2Id,
+                UserId = userId2,
+                Subtotal = 75.00m,
+                Tax = 7.50m,
+                ShippingCost = 3.50m,
+                Total = 86.00m,
+                Currency = "USD",
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                ShippingMethod = "Express",
+                TrackingNumber = null,
+                RefundedAmount = 0,
+                RefundedAt = null,
+                RefundReason = null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Items = new List<OrderItemDto>()
+            }
+        };
+        
+        var dataTableResult = new DataTableResult<OrderDetailDto>(1, 2, 2, mockOrders);
+        
+        // Mock user data
+        var user1 = new UserDto
+        {
+            Id = userId1,
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john.doe@example.com"
+        };
+        
+        var user2 = new UserDto
+        {
+            Id = userId2,
+            FirstName = "Jane",
+            LastName = "Smith",
+            Email = "jane.smith@example.com"
+        };
+        
+        // Mock order details
+        var orderDetail1 = new OrderDetailDto
+        {
+            Id = order1Id,
+            Items = new List<OrderItemDto>
+            {
+                new OrderItemDto { Id = Guid.NewGuid() },
+                new OrderItemDto { Id = Guid.NewGuid() }
+            }
+        };
+        
+        var orderDetail2 = new OrderDetailDto
+        {
+            Id = order2Id,
+            Items = new List<OrderItemDto>
+            {
+                new OrderItemDto { Id = Guid.NewGuid() }
+            }
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetOrderDetailDataTableAsync(It.IsAny<DataTableRequest>(), CancellationToken))
+            .ReturnsAsync(dataTableResult);
+            
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId1, CancellationToken))
+            .ReturnsAsync(user1);
+            
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId2, CancellationToken))
+            .ReturnsAsync(user2);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(order1Id, CancellationToken))
+            .ReturnsAsync(orderDetail1);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(order2Id, CancellationToken))
+            .ReturnsAsync(orderDetail2);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(2);
+        result.Value.RecordsFiltered.Should().Be(2);
+        result.Value.Data.Should().HaveCount(2);
+        
+        // Verify first order data
+        var firstOrder = result.Value.Data.First();
+        firstOrder.Id.Should().Be(order1Id);
+        firstOrder.UserEmail.Should().Be("john.doe@example.com");
+        firstOrder.UserFullName.Should().Be("John Doe");
+        firstOrder.Total.Should().Be(115.00m);
+        firstOrder.Status.Should().Be(OrderStatus.Delivered);
+        firstOrder.ItemsCount.Should().Be(2);
+        
+        // Verify second order data
+        var secondOrder = result.Value.Data.Last();
+        secondOrder.Id.Should().Be(order2Id);
+        secondOrder.UserEmail.Should().Be("jane.smith@example.com");
+        secondOrder.UserFullName.Should().Be("Jane Smith");
+        secondOrder.Total.Should().Be(86.00m);
+        secondOrder.Status.Should().Be(OrderStatus.Pending);
+        secondOrder.ItemsCount.Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task Handle_EmptyResults_ReturnsEmptyDataTableResult()
+    {
+        // Arrange
+        var query = new GetOrdersDatatableQueryV1
+        {
+            Request = new DataTableRequest
+            {
+                Draw = 1,
+                Start = 0,
+                Length = 10,
+                Search = new DataTableSearch { Value = "" },
+                Order = new List<DataTableOrder>(),
+                Columns = new List<DataTableColumn>()
+            }
+        };
+        
+        var emptyResult = new DataTableResult<OrderDetailDto>(1, 0, 0, new List<OrderDetailDto>());
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetOrderDetailDataTableAsync(It.IsAny<DataTableRequest>(), CancellationToken))
+            .ReturnsAsync(emptyResult);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Draw.Should().Be(1);
+        result.Value.RecordsTotal.Should().Be(0);
+        result.Value.RecordsFiltered.Should().Be(0);
+        result.Value.Data.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task Handle_OrderWithoutUser_HandlesNullUserGracefully()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        
+        var query = new GetOrdersDatatableQueryV1
+        {
+            Request = new DataTableRequest
+            {
+                Draw = 1,
+                Start = 0,
+                Length = 10,
+                Search = new DataTableSearch { Value = "" },
+                Order = new List<DataTableOrder>(),
+                Columns = new List<DataTableColumn>()
+            }
+        };
+        
+        var mockOrders = new List<OrderDetailDto>
+        {
+            new OrderDetailDto
+            {
+                Id = orderId,
+                UserId = null, // Order without user
+                Subtotal = 50.00m,
+                Tax = 5.00m,
+                ShippingCost = 2.00m,
+                Total = 57.00m,
+                Currency = "USD",
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Standard",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Items = new List<OrderItemDto>()
+            }
+        };
+        
+        var dataTableResult = new DataTableResult<OrderDetailDto>(1, 1, 1, mockOrders);
+        
+        var orderDetail = new OrderDetailDto
+        {
+            Id = orderId,
+            Items = new List<OrderItemDto> { new OrderItemDto { Id = Guid.NewGuid() } }
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetOrderDetailDataTableAsync(It.IsAny<DataTableRequest>(), CancellationToken))
+            .ReturnsAsync(dataTableResult);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync(orderDetail);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Data.Should().HaveCount(1);
+        
+        var order = result.Value.Data.First();
+        order.Id.Should().Be(orderId);
+        order.UserId.Should().BeNull();
+        order.UserEmail.Should().BeNull();
+        order.UserFullName.Should().BeNull();
+        order.ItemsCount.Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task Handle_OrderWithoutDetails_SetsItemsCountToZero()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        
+        var query = new GetOrdersDatatableQueryV1
+        {
+            Request = new DataTableRequest
+            {
+                Draw = 1,
+                Start = 0,
+                Length = 10,
+                Search = new DataTableSearch { Value = "" },
+                Order = new List<DataTableOrder>(),
+                Columns = new List<DataTableColumn>()
+            }
+        };
+        
+        var mockOrders = new List<OrderDetailDto>
+        {
+            new OrderDetailDto
+            {
+                Id = orderId,
+                UserId = userId,
+                Total = 100.00m,
+                Status = OrderStatus.Pending,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Items = new List<OrderItemDto>()
+            }
+        };
+        
+        var dataTableResult = new DataTableResult<OrderDetailDto>(1, 1, 1, mockOrders);
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com"
+        };
+        
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetOrderDetailDataTableAsync(It.IsAny<DataTableRequest>(), CancellationToken))
+            .ReturnsAsync(dataTableResult);
+            
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        // Order details not found
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetDetailByIdAsync(orderId, CancellationToken))
+            .ReturnsAsync((OrderDetailDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var order = result.Value.Data.First();
+        order.ItemsCount.Should().Be(0);
+    }
+    
+    [Fact]
+    public async Task Handle_DatabaseException_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetOrdersDatatableQueryV1
+        {
+            Request = new DataTableRequest
+            {
+                Draw = 1,
+                Start = 0,
+                Length = 10,
+                Search = new DataTableSearch { Value = "" },
+                Order = new List<DataTableOrder>(),
+                Columns = new List<DataTableColumn>()
+            }
+        };
+        
+        // Mock repository calls to throw exception
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetOrderDetailDataTableAsync(It.IsAny<DataTableRequest>(), CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Orders.GetDataTableFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Queries/GetRecentOrdersQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Queries/GetRecentOrdersQueryHandlerTests.cs
@@ -1,0 +1,305 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Queries.GetRecentOrders.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Domain.Payments.Enums;
+using Shopilent.Domain.Sales.DTOs;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Queries;
+
+public class GetRecentOrdersQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+
+    public GetRecentOrdersQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetRecentOrdersQueryHandlerV1>());
+
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetRecentOrdersQueryV1>();
+        });
+
+        // Register validator
+        services.AddTransient<FluentValidation.IValidator<GetRecentOrdersQueryV1>, GetRecentOrdersQueryValidatorV1>();
+
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsRecentOrders()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1
+        {
+            Count = 5
+        };
+
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Subtotal = 100.00m,
+                Tax = 10.00m,
+                ShippingCost = 5.00m,
+                Total = 115.00m,
+                Currency = "USD",
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Standard",
+                TrackingNumber = "TRACK-001",
+                CreatedAt = DateTime.UtcNow.AddDays(-1),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Subtotal = 75.00m,
+                Tax = 7.50m,
+                ShippingCost = 3.50m,
+                Total = 86.00m,
+                Currency = "USD",
+                Status = OrderStatus.Shipped,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Express",
+                TrackingNumber = "TRACK-002",
+                CreatedAt = DateTime.UtcNow.AddDays(-2),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Subtotal = 50.00m,
+                Tax = 5.00m,
+                ShippingCost = 2.50m,
+                Total = 57.50m,
+                Currency = "USD",
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                ShippingMethod = "Standard",
+                CreatedAt = DateTime.UtcNow.AddHours(-6),
+                UpdatedAt = DateTime.UtcNow.AddHours(-6)
+            }
+        };
+
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(5, CancellationToken))
+            .ReturnsAsync(mockOrders);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().HaveCount(3);
+
+        // Verify order data
+        var firstOrder = result.Value.First();
+        firstOrder.Total.Should().Be(115.00m);
+        firstOrder.Status.Should().Be(OrderStatus.Delivered);
+
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetRecentOrdersAsync(5, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DefaultCount_UsesDefaultValue()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1(); // Uses default count of 10
+
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Total = 100.00m,
+                Status = OrderStatus.Delivered,
+                CreatedAt = DateTime.UtcNow
+            }
+        };
+
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(10, CancellationToken))
+            .ReturnsAsync(mockOrders);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+
+        // Verify repository was called with default count
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetRecentOrdersAsync(10, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoOrdersFound_ReturnsEmptyList()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1
+        {
+            Count = 10
+        };
+
+        var emptyOrders = new List<OrderDto>();
+
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(10, CancellationToken))
+            .ReturnsAsync(emptyOrders);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().BeEmpty();
+
+        // Verify repository was called correctly
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetRecentOrdersAsync(10, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CustomCount_UsesSpecifiedCount()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1
+        {
+            Count = 20
+        };
+
+        var mockOrders = new List<OrderDto>();
+        for (int i = 1; i <= 15; i++)
+        {
+            mockOrders.Add(new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Total = 50.00m + i,
+                Status = OrderStatus.Delivered,
+                CreatedAt = DateTime.UtcNow.AddHours(-i)
+            });
+        }
+
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(20, CancellationToken))
+            .ReturnsAsync(mockOrders);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(15);
+
+        // Verify repository was called with custom count
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetRecentOrdersAsync(20, CancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_OrdersInDifferentStatuses_ReturnsAllOrders()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1
+        {
+            Count = 3
+        };
+
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                Total = 100.00m,
+                CreatedAt = DateTime.UtcNow
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                Total = 150.00m,
+                CreatedAt = DateTime.UtcNow.AddHours(-1)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                Status = OrderStatus.Cancelled,
+                PaymentStatus = PaymentStatus.Refunded,
+                Total = 75.00m,
+                CreatedAt = DateTime.UtcNow.AddHours(-2)
+            }
+        };
+
+        // Mock repository calls
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(3, CancellationToken))
+            .ReturnsAsync(mockOrders);
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(3);
+
+        // Verify all different statuses are included
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Pending);
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Delivered);
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Handle_DatabaseException_ReturnsFailureResult()
+    {
+        // Arrange
+        var query = new GetRecentOrdersQueryV1
+        {
+            Count = 10
+        };
+
+        // Mock repository calls to throw exception
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetRecentOrdersAsync(10, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Orders.GetRecentFailed");
+        result.Error.Message.Should().Contain("Database connection failed");
+    }
+}

--- a/Shopilent.Application.UnitTests/Features/Sales/Queries/GetUserOrdersQueryHandlerTests.cs
+++ b/Shopilent.Application.UnitTests/Features/Sales/Queries/GetUserOrdersQueryHandlerTests.cs
@@ -1,0 +1,440 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shopilent.Application.Features.Sales.Queries.GetUserOrders.V1;
+using Shopilent.Application.UnitTests.Common;
+using Shopilent.Application.UnitTests.Testing.Builders;
+using Shopilent.Domain.Identity.DTOs;
+using Shopilent.Domain.Identity.Errors;
+using Shopilent.Domain.Payments.Enums;
+using Shopilent.Domain.Sales.DTOs;
+using Shopilent.Domain.Sales.Enums;
+using Xunit;
+
+namespace Shopilent.Application.UnitTests.Features.Sales.Queries;
+
+public class GetUserOrdersQueryHandlerTests : TestBase
+{
+    private readonly IMediator _mediator;
+    
+    public GetUserOrdersQueryHandlerTests()
+    {
+        var services = new ServiceCollection();
+        
+        // Register handler dependencies
+        services.AddTransient(sp => Fixture.MockUnitOfWork.Object);
+        services.AddTransient(sp => Fixture.GetLogger<GetUserOrdersQueryHandlerV1>());
+        
+        // Set up MediatR
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssemblyContaining<GetUserOrdersQueryV1>();
+        });
+        
+        var provider = services.BuildServiceProvider();
+        _mediator = provider.GetRequiredService<IMediator>();
+    }
+    
+    [Fact]
+    public async Task Handle_ValidUserWithOrders_ReturnsUserOrders()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john.doe@example.com"
+        };
+        
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Subtotal = 100.00m,
+                Tax = 10.00m,
+                ShippingCost = 5.00m,
+                Total = 115.00m,
+                Currency = "USD",
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Standard",
+                TrackingNumber = "TRACK-001",
+                CreatedAt = DateTime.UtcNow.AddDays(-5),
+                UpdatedAt = DateTime.UtcNow.AddDays(-5)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Subtotal = 75.00m,
+                Tax = 7.50m,
+                ShippingCost = 3.50m,
+                Total = 86.00m,
+                Currency = "USD",
+                Status = OrderStatus.Shipped,
+                PaymentStatus = PaymentStatus.Succeeded,
+                ShippingMethod = "Express",
+                TrackingNumber = "TRACK-002",
+                CreatedAt = DateTime.UtcNow.AddDays(-2),
+                UpdatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Subtotal = 50.00m,
+                Tax = 5.00m,
+                ShippingCost = 2.50m,
+                Total = 57.50m,
+                Currency = "USD",
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                ShippingMethod = "Standard",
+                CreatedAt = DateTime.UtcNow.AddHours(-6),
+                UpdatedAt = DateTime.UtcNow.AddHours(-6)
+            }
+        };
+        
+        // Mock repository calls
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(mockOrders);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().HaveCount(3);
+        
+        // Verify all orders belong to the user
+        result.Value.Should().AllSatisfy(order => order.UserId.Should().Be(userId));
+        
+        // Verify order data
+        var firstOrder = result.Value.First(o => o.Total == 115.00m);
+        firstOrder.Total.Should().Be(115.00m);
+        firstOrder.Status.Should().Be(OrderStatus.Delivered);
+        firstOrder.TrackingNumber.Should().Be("TRACK-001");
+        
+        // Verify repository was called correctly
+        Fixture.MockUserReadRepository.Verify(
+            repo => repo.GetByIdAsync(userId, CancellationToken), 
+            Times.Once);
+            
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(userId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ValidUserWithNoOrders_ReturnsEmptyList()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane.doe@example.com"
+        };
+        
+        var emptyOrders = new List<OrderDto>();
+        
+        // Mock repository calls
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(emptyOrders);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().BeEmpty();
+        
+        // Verify repository was called correctly
+        Fixture.MockUserReadRepository.Verify(
+            repo => repo.GetByIdAsync(userId, CancellationToken), 
+            Times.Once);
+            
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(userId, CancellationToken), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_NonExistentUser_ReturnsNotFoundError()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        // Mock repository calls - user not found
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync((UserDto)null);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(UserErrors.NotFound(userId).Code);
+        
+        // Verify user repository was called, but order repository was not
+        Fixture.MockUserReadRepository.Verify(
+            repo => repo.GetByIdAsync(userId, CancellationToken), 
+            Times.Once);
+            
+        Fixture.MockOrderReadRepository.Verify(
+            repo => repo.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_UserWithOrdersInDifferentStatuses_ReturnsAllOrders()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com"
+        };
+        
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                Total = 100.00m,
+                CreatedAt = DateTime.UtcNow
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                Total = 150.00m,
+                CreatedAt = DateTime.UtcNow.AddHours(-1)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Cancelled,
+                PaymentStatus = PaymentStatus.Canceled,
+                Total = 75.00m,
+                CreatedAt = DateTime.UtcNow.AddHours(-2)
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Cancelled,
+                PaymentStatus = PaymentStatus.Refunded,
+                Total = 200.00m,
+                CreatedAt = DateTime.UtcNow.AddDays(-1)
+            }
+        };
+        
+        // Mock repository calls
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(mockOrders);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(4);
+        
+        // Verify all different statuses are included
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Pending);
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Delivered);
+        result.Value.Should().Contain(o => o.Status == OrderStatus.Cancelled);
+        result.Value.Should().Contain(o => o.PaymentStatus == PaymentStatus.Refunded);
+        
+        // Verify all orders belong to the user
+        result.Value.Should().AllSatisfy(order => order.UserId.Should().Be(userId));
+    }
+    
+    [Fact]
+    public async Task Handle_OrdersWithDifferentPaymentStatuses_ReturnsAllOrders()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "Payment",
+            LastName = "User",
+            Email = "payment@example.com"
+        };
+        
+        var mockOrders = new List<OrderDto>
+        {
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Pending,
+                PaymentStatus = PaymentStatus.Pending,
+                Total = 100.00m
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Delivered,
+                PaymentStatus = PaymentStatus.Succeeded,
+                Total = 150.00m
+            },
+            new OrderDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Status = OrderStatus.Cancelled,
+                PaymentStatus = PaymentStatus.Failed,
+                Total = 75.00m
+            }
+        };
+        
+        // Mock repository calls
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ReturnsAsync(mockOrders);
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(3);
+        
+        // Verify different payment statuses are included
+        result.Value.Should().Contain(o => o.PaymentStatus == PaymentStatus.Pending);
+        result.Value.Should().Contain(o => o.PaymentStatus == PaymentStatus.Succeeded);
+        result.Value.Should().Contain(o => o.PaymentStatus == PaymentStatus.Failed);
+    }
+    
+    [Fact]
+    public async Task Handle_DatabaseExceptionOnUserLookup_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        // Mock repository calls to throw exception
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("User database connection failed"));
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Orders.GetUserOrdersFailed");
+        result.Error.Message.Should().Contain("User database connection failed");
+    }
+    
+    [Fact]
+    public async Task Handle_DatabaseExceptionOnOrderLookup_ReturnsFailureResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        
+        var query = new GetUserOrdersQueryV1
+        {
+            UserId = userId
+        };
+        
+        var user = new UserDto
+        {
+            Id = userId,
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com"
+        };
+        
+        // Mock repository calls
+        Fixture.MockUserReadRepository
+            .Setup(repo => repo.GetByIdAsync(userId, CancellationToken))
+            .ReturnsAsync(user);
+            
+        Fixture.MockOrderReadRepository
+            .Setup(repo => repo.GetByUserIdAsync(userId, CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Order database connection failed"));
+        
+        // Act
+        var result = await _mediator.Send(query, CancellationToken);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be("Orders.GetUserOrdersFailed");
+        result.Error.Message.Should().Contain("Order database connection failed");
+    }
+}


### PR DESCRIPTION
- Introduced unit tests for `AddItemToCartCommandHandler`, `AssignCartToUserCommandHandler`, `CancelOrderCommandHandler`, and `ClearCartCommandHandler`.
- Covered various scenarios, including valid requests, error handling, and edge cases.
- Utilized `FluentAssertions` for expressive and readable assertions.
- Set up dependency injection and MediatR pipeline for test handlers.