### PR TITLE
Add integration test project for infrastructure

### DIFF
--- a/Shopilent-API.sln
+++ b/Shopilent-API.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{5E18
 		scripts\postgres-primary-init.sh = scripts\postgres-primary-init.sh
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shopilent.Infrastructure.IntegrationTests", "Shopilent.Infrastructure.IntegrationTests\Shopilent.Infrastructure.IntegrationTests.csproj", "{79630144-DE1A-4331-AD58-069BF28AE897}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -136,6 +138,10 @@ Global
 		{544175F3-59A1-4FF8-A41F-4261EC654187}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{544175F3-59A1-4FF8-A41F-4261EC654187}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{544175F3-59A1-4FF8-A41F-4261EC654187}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79630144-DE1A-4331-AD58-069BF28AE897}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79630144-DE1A-4331-AD58-069BF28AE897}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79630144-DE1A-4331-AD58-069BF28AE897}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79630144-DE1A-4331-AD58-069BF28AE897}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -162,6 +168,7 @@ Global
 		{4F4C987E-2EB1-B5D0-1FDE-6E4950B8BA35} = {9CF72851-172A-482E-81B4-5113748D4758}
 		{544175F3-59A1-4FF8-A41F-4261EC654187} = {463540A1-2D10-4BA8-B838-31CD0C03B9D7}
 		{5E1874A2-0FE3-463A-9EFF-5115F27C7AF9} = {BAD6D0A2-1DE0-4588-877F-2027B0786731}
+		{79630144-DE1A-4331-AD58-069BF28AE897} = {9752E1C1-67E6-4F5E-896F-676AF1FDF425}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {704BEEEA-8630-404F-BEAB-1F9DE6F66368}

--- a/Shopilent.Infrastructure.IntegrationTests/AssemblyInfo.cs
+++ b/Shopilent.Infrastructure.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Shopilent.Infrastructure.IntegrationTests/Shopilent.Infrastructure.IntegrationTests.csproj
+++ b/Shopilent.Infrastructure.IntegrationTests/Shopilent.Infrastructure.IntegrationTests.csproj
@@ -1,0 +1,64 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- Core Testing -->
+        <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+
+        <!-- Mocking & Test Data -->
+        <PackageReference Include="Moq" Version="4.20.72"/>
+        <PackageReference Include="AutoFixture" Version="4.18.1"/>
+        <PackageReference Include="Bogus" Version="35.6.3" />
+
+        <!-- Integration Testing -->
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11"/>
+        <PackageReference Include="Testcontainers" Version="4.0.0"/>
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0"/>
+        <PackageReference Include="Testcontainers.Redis" Version="4.0.0"/>
+        <PackageReference Include="Testcontainers.Minio" Version="4.0.0"/>
+
+        <!-- Database Testing -->
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4"/>
+        <PackageReference Include="Dapper" Version="2.1.66"/>
+        <PackageReference Include="Respawn" Version="6.2.1"/>
+
+        <!-- Logging for Tests -->
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3"/>
+        <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0"/>
+
+        <!-- Additional Infrastructure Dependencies -->
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="FluentAssertions"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Project References -->
+        <ProjectReference Include="..\Shopilent.Domain\Shopilent.Domain.csproj"/>
+        <ProjectReference Include="..\Shopilent.Application\Shopilent.Application.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure\Shopilent.Infrastructure.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Identity\Shopilent.Infrastructure.Identity.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Cache.Redis\Shopilent.Infrastructure.Cache.Redis.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Persistence.PostgreSQL\Shopilent.Infrastructure.Persistence.PostgreSQL.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.S3ObjectStorage\Shopilent.Infrastructure.S3ObjectStorage.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Payments\Shopilent.Infrastructure.Payments.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Search.Meilisearch\Shopilent.Infrastructure.Search.Meilisearch.csproj"/>
+        <ProjectReference Include="..\Shopilent.Infrastructure.Logging\Shopilent.Infrastructure.Logging.csproj"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Introduced `Shopilent.Infrastructure.IntegrationTests` project.
- Configured test project dependencies, including `xUnit`, `FluentAssertions`, `Testcontainers`, and EntityFramework providers.
- Set up required project references and added new project to the solution.
- Disabled parallel test execution to ensure reliability in integration tests.