### PR TITLE
Remove redundant user and admin existence setup in integration tests

### DIFF
--- a/Shopilent.API.IntegrationTests/Common/ApiIntegrationTestBase.cs
+++ b/Shopilent.API.IntegrationTests/Common/ApiIntegrationTestBase.cs
@@ -111,11 +111,7 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
     // Authentication helpers
     protected async Task<string> AuthenticateAsync(string email = "admin@shopilent.com", string password = "Admin123!")
     {
-        var loginRequest = new
-        {
-            Email = email,
-            Password = password
-        };
+        var loginRequest = new { Email = email, Password = password };
 
         var response = await Client.PostAsJsonAsync("v1/auth/login", loginRequest, JsonOptions);
 
@@ -127,16 +123,19 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
         var content = await response.Content.ReadAsStringAsync();
         var loginResponse = JsonSerializer.Deserialize<ApiResponse<LoginResponse>>(content, JsonOptions);
 
-        return loginResponse?.Data?.AccessToken ?? throw new InvalidOperationException("Access token not found in response");
+        return loginResponse?.Data?.AccessToken ??
+               throw new InvalidOperationException("Access token not found in response");
     }
 
     protected async Task<string> AuthenticateAsAdminAsync()
     {
+        await EnsureAdminUserExistsAsync();
         return await AuthenticateAsync("admin@shopilent.com", "Admin123!");
     }
 
     protected async Task<string> AuthenticateAsCustomerAsync()
     {
+        await EnsureCustomerUserExistsAsync();
         return await AuthenticateAsync("customer@shopilent.com", "Customer123!");
     }
 
@@ -185,7 +184,8 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
         return await Client.DeleteAsync(endpoint);
     }
 
-    protected async Task<ApiResponse<TestDataTableResult<T>>?> PostDataTableResponseAsync<T>(string endpoint, object request)
+    protected async Task<ApiResponse<TestDataTableResult<T>>?> PostDataTableResponseAsync<T>(string endpoint,
+        object request)
     {
         var response = await Client.PostAsJsonAsync(endpoint, request, JsonOptions);
         var json = await response.Content.ReadAsStringAsync();
@@ -241,12 +241,12 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
             {
                 var changeRoleCommand = new ChangeUserRoleCommandV1
                 {
-                    UserId = existingUser.Id,
-                    NewRole = UserRole.Admin
+                    UserId = existingUser.Id, NewRole = UserRole.Admin
                 };
 
                 await mediator.Send(changeRoleCommand);
             }
+
             return;
         }
 
@@ -271,8 +271,7 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
                 // Set role to Admin after registration
                 var changeRoleCommand = new ChangeUserRoleCommandV1
                 {
-                    UserId = registerResult.Value.User.Id,
-                    NewRole = UserRole.Admin
+                    UserId = registerResult.Value.User.Id, NewRole = UserRole.Admin
                 };
 
                 await mediator.Send(changeRoleCommand);
@@ -288,10 +287,7 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
     {
         var registerRequest = new
         {
-            Email = "customer@shopilent.com",
-            Password = "Customer123!",
-            FirstName = "Customer",
-            LastName = "User"
+            Email = "customer@shopilent.com", Password = "Customer123!", FirstName = "Customer", LastName = "User"
         };
 
         var response = await PostAsync("v1/auth/register", registerRequest);
@@ -317,12 +313,12 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
             {
                 var changeRoleCommand = new ChangeUserRoleCommandV1
                 {
-                    UserId = existingUser.Id,
-                    NewRole = UserRole.Manager
+                    UserId = existingUser.Id, NewRole = UserRole.Manager
                 };
 
                 await mediator.Send(changeRoleCommand);
             }
+
             return;
         }
 
@@ -347,8 +343,7 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
                 // Set role to Manager after registration
                 var changeRoleCommand = new ChangeUserRoleCommandV1
                 {
-                    UserId = registerResult.Value.User.Id,
-                    NewRole = UserRole.Manager
+                    UserId = registerResult.Value.User.Id, NewRole = UserRole.Manager
                 };
 
                 await mediator.Send(changeRoleCommand);
@@ -364,7 +359,8 @@ public abstract class ApiIntegrationTestBase : IAsyncLifetime
     protected async Task ProcessOutboxMessagesAsync(CancellationToken cancellationToken = default)
     {
         using var scope = Factory.Services.CreateScope();
-        var outboxService = scope.ServiceProvider.GetRequiredService<Shopilent.Application.Abstractions.Outbox.IOutboxService>();
+        var outboxService = scope.ServiceProvider
+            .GetRequiredService<Shopilent.Application.Abstractions.Outbox.IOutboxService>();
         await outboxService.ProcessMessagesAsync(cancellationToken);
     }
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Administration/ClearAllCache/V1/ClearAllCacheEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Administration/ClearAllCache/V1/ClearAllCacheEndpointV1Tests.cs
@@ -17,7 +17,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_WithValidAdminAuthentication_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -42,7 +41,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_WithCacheEntries_ShouldClearAllEntries()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -100,7 +98,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_WithEmptyCache_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -140,7 +137,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -155,7 +151,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_WithDifferentCachePatterns_ShouldClearAllPatterns()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -212,7 +207,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -272,7 +266,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_AfterCachingQueries_ShouldClearQueryCache()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -327,7 +320,6 @@ public class ClearAllCacheEndpointV1Tests : ApiIntegrationTestBase
     public async Task ClearAllCache_ShouldReturnCorrectResponseFormat()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Administration/RebuildSearchIndex/V1/RebuildSearchIndexEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Administration/RebuildSearchIndex/V1/RebuildSearchIndexEndpointV1Tests.cs
@@ -14,7 +14,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithValidDataAsAdmin_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CreateValidRequest();
@@ -36,7 +35,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithDefaultRequest_ShouldInitializeAndIndexProducts()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CommonScenarios.CreateDefaultRequest();
@@ -56,7 +54,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithInitializeOnlyRequest_ShouldInitializeButNotIndexProducts()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CommonScenarios.CreateInitializeOnlyRequest();
@@ -76,7 +73,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithIndexProductsOnlyRequest_ShouldIndexProductsWithoutInitializing()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CommonScenarios.CreateIndexProductsOnlyRequest();
@@ -96,7 +92,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithForceReindexRequest_ShouldForceReindexing()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CommonScenarios.CreateForceReindexRequest();
@@ -116,7 +111,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithMinimalRequest_ShouldReturnSuccessWithMinimalAction()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CommonScenarios.CreateMinimalRequest();
@@ -150,7 +144,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CreateValidRequest();
@@ -172,7 +165,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
         bool initializeIndexes, bool indexProducts, bool forceReindex)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CreateValidRequest(
@@ -203,7 +195,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithAllFalseParameters_ShouldStillReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.EdgeCases.CreateAllFalseRequest();
@@ -224,7 +215,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_WithOnlyForceReindex_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.EdgeCases.CreateOnlyForceReindexRequest();
@@ -244,7 +234,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var tasks = Enumerable.Range(0, 3) // Reduced concurrent requests for search operations
@@ -266,7 +255,6 @@ public class RebuildSearchIndexEndpointV1Tests : ApiIntegrationTestBase
     public async Task RebuildSearchIndex_ValidRequest_ShouldHaveReasonableResponseTime()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = RebuildSearchIndexTestDataV1.CreateValidRequest();

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/CreateAttribute/V1/CreateAttributeEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/CreateAttribute/V1/CreateAttributeEndpointV1Tests.cs
@@ -20,7 +20,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithValidData_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest();
@@ -42,7 +41,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithValidData_ShouldCreateAttributeInDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest(
@@ -82,7 +80,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithAllValidTypes_ShouldReturnSuccess(string attributeType)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest(type: attributeType);
@@ -103,7 +100,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithTextType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.TypeSpecific.CreateTextAttributeRequest();
@@ -122,7 +118,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithSelectType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.TypeSpecific.CreateSelectAttributeRequest();
@@ -141,7 +136,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithColorType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.TypeSpecific.CreateColorAttributeRequest();
@@ -164,7 +158,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithEmptyName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithEmptyName();
@@ -184,7 +177,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithNullName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithNullName();
@@ -204,7 +196,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithWhitespaceName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithWhitespaceName();
@@ -224,7 +215,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithLongName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithLongName();
@@ -248,7 +238,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithEmptyDisplayName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithEmptyDisplayName();
@@ -268,7 +257,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithLongDisplayName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithLongDisplayName();
@@ -292,7 +280,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithEmptyType_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithEmptyType();
@@ -312,7 +299,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithInvalidType_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Validation.CreateRequestWithInvalidType();
@@ -343,7 +329,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithDifferentCaseTypes_ShouldReturnSuccess(string type)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest(type: type);
@@ -378,7 +363,7 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest();
@@ -394,7 +379,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithAdminRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest();
@@ -414,7 +398,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithMaximumNameLength_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.BoundaryTests.CreateRequestWithMaximumNameLength();
@@ -431,7 +414,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithMaximumDisplayNameLength_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.BoundaryTests.CreateRequestWithMaximumDisplayNameLength();
@@ -448,7 +430,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithMinimumValidName_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.BoundaryTests.CreateRequestWithMinimumValidName();
@@ -469,7 +450,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithUnicodeCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.EdgeCases.CreateRequestWithUnicodeCharactersForCreate();
@@ -487,7 +467,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithSpecialCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.EdgeCases.CreateRequestWithSpecialCharactersForCreate();
@@ -504,7 +483,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithEmptyConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.EdgeCases.CreateRequestWithEmptyConfiguration();
@@ -521,7 +499,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithComplexConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.EdgeCases.CreateRequestWithComplexConfiguration();
@@ -543,7 +520,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_WithDuplicateName_ShouldReturnConflict()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var uniqueName = $"duplicate_test_{Guid.NewGuid():N}";
@@ -573,7 +549,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task CreateAttribute_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var tasks = Enumerable.Range(0, 5)
@@ -604,7 +579,6 @@ public class CreateAttributeEndpointV1Tests : ApiIntegrationTestBase
         bool filterable, bool searchable, bool isVariant)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = AttributeTestDataV1.Creation.CreateValidRequest(

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/DeleteAttribute/V1/DeleteAttributeEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/DeleteAttribute/V1/DeleteAttributeEndpointV1Tests.cs
@@ -21,7 +21,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithValidId_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -47,7 +46,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithValidId_ShouldRemoveAttributeFromDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -98,7 +96,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithAllAttributeTypes_ShouldReturnSuccess(string attributeType)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -129,7 +126,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_TextType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -153,7 +149,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_SelectType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -177,7 +172,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_ColorType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -201,7 +195,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_NumberType_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -229,7 +222,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithEmptyGuid_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -248,7 +240,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithInvalidGuidFormat_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -263,7 +254,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithNonExistentId_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var nonExistentId = Guid.NewGuid();
@@ -301,7 +291,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var attributeId = Guid.NewGuid();
@@ -317,7 +306,7 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithAdminRole_ShouldReturnNotFoundForNonExistentAttribute()
     {
         // Arrange - Test that admin has permission, but attribute doesn't exist
-        await EnsureAdminUserExistsAsync();
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var nonExistentId = Guid.NewGuid();
@@ -337,7 +326,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_UsedByProducts_ShouldReturnConflict()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -371,7 +359,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_AlreadyDeleted_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -404,7 +391,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithUnicodeCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -428,7 +414,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithComplexConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -452,7 +437,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_WithMaximumNameLength_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -486,7 +470,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
         bool filterable, bool searchable, bool isVariant)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -517,7 +500,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -545,7 +527,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_SequentialDeletes_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -580,7 +561,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_ThenAttemptToGetIt_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -631,7 +611,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_ThenAttemptToUpdateIt_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -669,7 +648,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_SuccessResponse_ShouldHaveCorrectFormat()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -699,7 +677,6 @@ public class DeleteAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task DeleteAttribute_ErrorResponse_ShouldHaveCorrectFormat()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var nonExistentId = Guid.NewGuid();

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAllAttributes/V1/GetAllAttributesEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAllAttributes/V1/GetAllAttributesEndpointV1Tests.cs
@@ -47,7 +47,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithCreatedAttribute_ShouldIncludeCreatedAttribute()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -92,7 +91,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithMultipleAttributes_ShouldReturnAllCreatedAttributes()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -144,7 +142,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithAllAttributeTypes_ShouldIncludeAllCreatedTypes()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -195,7 +192,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_ShouldReturnAttributesWithCorrectStructure()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -264,7 +260,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithCustomerAuthentication_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -280,7 +275,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithAdminAuthentication_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -300,7 +294,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_ShouldReturnDataConsistentWithDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -376,7 +369,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_ShouldReturnAttributesInConsistentOrder()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -421,7 +413,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithUnicodeCharacters_ShouldReturnCorrectly()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -452,7 +443,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithComplexConfiguration_ShouldReturnCorrectly()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -487,7 +477,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_WithManyAttributes_ShouldPerformWell()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -519,7 +508,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_ConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -556,7 +544,6 @@ public class GetAllAttributesEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAllAttributes_ShouldBeCached()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAttribute/V1/GetAttributeEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAttribute/V1/GetAttributeEndpointV1Tests.cs
@@ -21,7 +21,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithValidId_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -55,7 +54,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithValidId_ShouldReturnCorrectData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -93,7 +91,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithDifferentTypes_ShouldReturnCorrectType(string attributeType)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -164,7 +161,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithoutAuthentication_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -190,7 +186,7 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithCustomerRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -201,7 +197,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
         var attributeId = createResponse!.Data.Id;
 
         // Switch to customer authentication
-        await EnsureCustomerUserExistsAsync();
         var customerToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(customerToken);
 
@@ -222,7 +217,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithComplexConfiguration_ShouldReturnCompleteData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -250,7 +244,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithEmptyConfiguration_ShouldReturnEmptyConfig()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -279,7 +272,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_WithUnicodeCharacters_ShouldReturnCorrectData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -309,7 +301,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_ShouldReturnDataFromDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -366,7 +357,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_CalledTwice_ShouldReturnConsistentData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -406,7 +396,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_ShouldReturnProperApiResponseFormat()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -437,7 +426,6 @@ public class GetAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttribute_AllSupportedTypes_ShouldReturnCorrectData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAttributesDatatable/V1/GetAttributesDatatableEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/GetAttributesDatatable/V1/GetAttributesDatatableEndpointV1Tests.cs
@@ -20,7 +20,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithValidRequest_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.CreateValidRequest();
@@ -42,7 +41,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithTestAttributes_ShouldReturnCorrectData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
 
         // Create test attributes
         await CreateTestAttributeAsync("color", "Color", AttributeType.Text, true, true, false);
@@ -77,7 +76,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithPagination_ShouldReturnCorrectPage()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestAttributesAsync(8);
 
         var accessToken = await AuthenticateAsAdminAsync();
@@ -111,7 +110,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithSearch_ShouldReturnFilteredResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("searchable_color", "Searchable Color", AttributeType.Text, true, true, false);
         await CreateTestAttributeAsync("another_size", "Another Size", AttributeType.Text, true, true, true);
 
@@ -134,7 +133,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithSorting_ShouldReturnSortedResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("alpha_attr", "Alpha Attribute", AttributeType.Text, true, true, false);
         await CreateTestAttributeAsync("beta_attr", "Beta Attribute", AttributeType.Text, true, true, false);
         await CreateTestAttributeAsync("gamma_attr", "Gamma Attribute", AttributeType.Text, true, true, false);
@@ -159,7 +158,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithDescendingSortByCreatedAt_ShouldReturnNewestFirst()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var oldAttributeId = await CreateTestAttributeAsync("old_attr", "Old Attribute", AttributeType.Text, true, true, false);
         await Task.Delay(1000); // Ensure different timestamps
         var newAttributeId = await CreateTestAttributeAsync("new_attr", "New Attribute", AttributeType.Text, true, true, false);
@@ -197,7 +196,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.CreateValidRequest();
@@ -213,7 +211,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithManagerRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("manager@test.com", "Manager", "User", UserRole.Manager);
         var accessToken = await AuthenticateAsync("manager@test.com", "Password123!");
         SetAuthenticationHeader(accessToken);
@@ -231,7 +229,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithZeroLength_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.Pagination.CreateZeroLengthRequest();
@@ -251,7 +248,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithNegativeValues_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.ValidationTests.CreateNegativeStartRequest();
@@ -271,7 +267,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithExcessiveLength_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.ValidationTests.CreateExcessiveLengthRequest();
@@ -291,7 +286,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithNoResultsSearch_ShouldReturnEmptyData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.SearchScenarios.CreateNoResultsSearchRequest();
@@ -311,7 +305,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithUnicodeSearch_ShouldReturnCorrectResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("groesse", "Größe", AttributeType.Text, true, true, false);
 
         var accessToken = await AuthenticateAsAdminAsync();
@@ -332,7 +326,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithComplexRequest_ShouldHandleAllParameters()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("complex1", "Complex Attribute 1", AttributeType.Text, true, true, false);
         await CreateTestAttributeAsync("complex2", "Complex Attribute 2", AttributeType.Number, false, true, true);
 
@@ -354,7 +348,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithInvalidColumnSort_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.SortingScenarios.CreateInvalidColumnSortRequest();
@@ -370,7 +363,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_ConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -400,7 +392,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithEmptySearch_ShouldReturnAllAttributes()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("empty_test", "Empty Test", AttributeType.Text, true, true, false);
 
         var accessToken = await AuthenticateAsAdminAsync();
@@ -421,7 +413,6 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithHighPageNumber_ShouldReturnEmptyOrLastPage()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetAttributesDatatableTestDataV1.Pagination.CreateHighStartRequest();
@@ -441,7 +432,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_DatabaseConsistency_ShouldMatchDatabaseCounts()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var testAttribute1Id = await CreateTestAttributeAsync("db_test1", "Database Test 1", AttributeType.Text, true, true, false);
         var testAttribute2Id = await CreateTestAttributeAsync("db_test2", "Database Test 2", AttributeType.Number, false, true, true);
 
@@ -477,7 +468,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithDifferentPageSizes_ShouldReturnCorrectCount(int pageSize)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestAttributesAsync(15); // Create enough attributes to test pagination
 
         var accessToken = await AuthenticateAsAdminAsync();
@@ -500,7 +491,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_ResponseTime_ShouldBeReasonable()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestAttributesAsync(50); // Create a decent amount of data
 
         var accessToken = await AuthenticateAsAdminAsync();
@@ -521,7 +512,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithFilterableAttributes_ShouldShowCorrectFlags()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("filterable_attr", "Filterable Attribute", AttributeType.Text, true, false, false);
         await CreateTestAttributeAsync("non_filterable_attr", "Non-Filterable Attribute", AttributeType.Text, false, true, false);
 
@@ -550,7 +541,7 @@ public class GetAttributesDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetAttributesDatatable_WithVariantAttributes_ShouldShowCorrectFlags()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestAttributeAsync("variant_attr", "Variant Attribute", AttributeType.Text, true, true, true);
         await CreateTestAttributeAsync("product_attr", "Product Attribute", AttributeType.Text, true, true, false);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/UpdateAttribute/V1/UpdateAttributeEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Catalog/Attributes/UpdateAttribute/V1/UpdateAttributeEndpointV1Tests.cs
@@ -20,7 +20,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithValidData_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -57,7 +56,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithValidData_ShouldUpdateAttributeInDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -101,7 +99,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithComplexConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -139,7 +136,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithInvalidDisplayName_ShouldReturnValidationError(string invalidDisplayName)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -166,7 +162,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithNullDisplayName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -193,7 +188,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithLongDisplayName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -220,7 +214,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithInvalidAttributeId_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -238,7 +231,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithMalformedGuid_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -275,7 +267,7 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -293,7 +285,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithAdminRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -321,7 +312,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithMaximumValidDisplayNameLength_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -345,7 +335,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithMinimumValidDisplayNameLength_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -373,7 +362,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithUnicodeCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -399,7 +387,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithSpecialCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -423,7 +410,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithEmptyConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -448,7 +434,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithNullConfiguration_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -476,7 +461,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithAllFilterableSearchableVariant_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -503,7 +487,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_WithAllFalseFlags_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -532,7 +515,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
         object requestData, string expectedDisplayName, bool expectedFilterable, bool expectedSearchable, bool expectedIsVariant)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -581,7 +563,6 @@ public class UpdateAttributeEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateAttribute_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Identity/Login/V1/LoginEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Identity/Login/V1/LoginEndpointV1Tests.cs
@@ -16,7 +16,7 @@ public class LoginEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure admin user exists
         await EnsureAdminUserExistsAsync();
-        
+
         var request = LoginTestDataV1.CreateValidRequest(
             email: "admin@shopilent.com",
             password: "Admin123!");
@@ -42,7 +42,7 @@ public class LoginEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure customer user exists
         await EnsureCustomerUserExistsAsync();
-        
+
         var request = LoginTestDataV1.CreateValidRequest(
             email: "customer@shopilent.com",
             password: "Customer123!");
@@ -63,7 +63,7 @@ public class LoginEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure admin user exists
         await EnsureAdminUserExistsAsync();
-        
+
         var request = new { Email = "admin@shopilent.com", Password = "Admin123!", RememberMe = true };
 
         // Act
@@ -421,7 +421,7 @@ public class LoginEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure admin user exists
         await EnsureAdminUserExistsAsync();
-        
+
         var tasks = Enumerable.Range(0, 5)
             .Select(_ => LoginTestDataV1.CreateValidRequest(
                 email: "admin@shopilent.com",
@@ -442,7 +442,7 @@ public class LoginEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure admin user exists
         await EnsureAdminUserExistsAsync();
-        
+
         var request = LoginTestDataV1.CreateValidRequest(
             email: "admin@shopilent.com",
             password: "Admin123!");

--- a/Shopilent.API.IntegrationTests/Endpoints/Identity/Logout/V1/LogoutEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Identity/Logout/V1/LogoutEndpointV1Tests.cs
@@ -81,7 +81,7 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
 
         var refreshToken = loginResponse!.Data.RefreshToken;
         var logoutRequest = LogoutTestDataV1.LogoutReasons.CreateRequestWithUserInitiatedLogout();
-        
+
         // Update the request with the actual refresh token
         logoutRequest = new { RefreshToken = refreshToken, Reason = "User initiated logout" };
 
@@ -100,7 +100,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithEmptyRefreshToken_ShouldReturnValidationError()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.CreateRequestWithEmptyRefreshToken();
@@ -120,7 +119,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithNullRefreshToken_ShouldReturnValidationError()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.CreateRequestWithNullRefreshToken();
@@ -140,7 +138,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithInvalidRefreshToken_ShouldReturnUnauthorized()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.CreateRequestWithInvalidRefreshToken();
@@ -160,10 +157,9 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithNonExistentRefreshToken_ShouldReturnUnauthorized()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
-        
+
         // Use a valid format but non-existent refresh token (UUID format)
         var request = new
         {
@@ -217,7 +213,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithInvalidRefreshToken_ShouldReturnValidationError(string? invalidToken)
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = new { RefreshToken = invalidToken, Reason = "User logged out" };
@@ -261,7 +256,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithSqlInjectionAttempt_ShouldReturnBadRequestSafely()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.SecurityTests.CreateSqlInjectionAttempt();
@@ -282,7 +276,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithXssAttempt_ShouldReturnBadRequestSafely()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.SecurityTests.CreateXssAttempt();
@@ -302,7 +295,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithExcessivelyLongRefreshToken_ShouldReturnValidationError()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.SecurityTests.CreateLongRefreshTokenAttack();
@@ -322,7 +314,6 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
     public async Task Logout_WithExcessivelyLongReason_ShouldReturnValidationError()
     {
         // Arrange - First ensure admin user exists
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = LogoutTestDataV1.SecurityTests.CreateLongReasonAttack();
@@ -349,10 +340,10 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
         AssertApiSuccess(loginResponse);
 
         var refreshToken = loginResponse!.Data.RefreshToken;
-        var request = new 
-        { 
-            RefreshToken = refreshToken, 
-            Reason = "Üser lögöut with spëcial çharacters" 
+        var request = new
+        {
+            RefreshToken = refreshToken,
+            Reason = "Üser lögöut with spëcial çharacters"
         };
 
         // Set authentication header for the logout request
@@ -375,10 +366,10 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
         AssertApiSuccess(loginResponse);
 
         var refreshToken = loginResponse!.Data.RefreshToken;
-        var request = new 
-        { 
-            RefreshToken = refreshToken, 
-            Reason = "  User logged out  " 
+        var request = new
+        {
+            RefreshToken = refreshToken,
+            Reason = "  User logged out  "
         };
 
         // Set authentication header for the logout request
@@ -401,9 +392,9 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
         AssertApiSuccess(loginResponse);
 
         var refreshToken = loginResponse!.Data.RefreshToken;
-        var request = new 
-        { 
-            RefreshToken = refreshToken, 
+        var request = new
+        {
+            RefreshToken = refreshToken,
             Reason = "   " // Only whitespace reason should be accepted since no validation
         };
 
@@ -428,9 +419,9 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
         AssertApiSuccess(loginResponse);
 
         var refreshToken = loginResponse!.Data.RefreshToken;
-        var request = new 
-        { 
-            RefreshToken = refreshToken, 
+        var request = new
+        {
+            RefreshToken = refreshToken,
             Reason = "a" // Minimum length reason
         };
 
@@ -451,7 +442,7 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
         // Arrange - Login multiple times to get different refresh tokens
         await EnsureAdminUserExistsAsync();
         var loginRequest = new { Email = "admin@shopilent.com", Password = "Admin123!", RememberMe = false };
-        
+
         var loginTasks = Enumerable.Range(0, 3)
             .Select(_ => PostApiResponseAsync<object, LoginResponseDto>("v1/auth/login", loginRequest))
             .ToList();
@@ -492,7 +483,7 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
 
         var refreshToken = loginResponse!.Data.RefreshToken;
         var logoutRequest = LogoutTestDataV1.LogoutReasons.CreateRequestWithPasswordChange();
-        
+
         // Update the request with the actual refresh token
         logoutRequest = new { RefreshToken = refreshToken, Reason = "Password changed - logout required" };
 
@@ -519,10 +510,11 @@ public class LogoutEndpointV1Tests : ApiIntegrationTestBase
             "User initiated logout"
         };
 
+        await EnsureAdminUserExistsAsync();
+
         foreach (var reason in reasons)
         {
             // Arrange - Login for each test
-            await EnsureAdminUserExistsAsync();
             var loginRequest = new { Email = "admin@shopilent.com", Password = "Admin123!", RememberMe = false };
             var loginResponse = await PostApiResponseAsync<object, LoginResponseDto>("v1/auth/login", loginRequest);
             AssertApiSuccess(loginResponse);

--- a/Shopilent.API.IntegrationTests/Endpoints/Identity/RefreshToken/V1/RefreshTokenEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Identity/RefreshToken/V1/RefreshTokenEndpointV1Tests.cs
@@ -16,11 +16,8 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First login to get a valid refresh token
         await EnsureAdminUserExistsAsync();
-        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login", new
-        {
-            Email = "admin@shopilent.com",
-            Password = "Admin123!"
-        });
+        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login",
+            new { Email = "admin@shopilent.com", Password = "Admin123!" });
 
         AssertApiSuccess(loginResponse);
         var validRefreshToken = loginResponse!.Data.RefreshToken;
@@ -46,18 +43,16 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - Login to get a valid refresh token
         await EnsureAdminUserExistsAsync();
-        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login", new
-        {
-            Email = "admin@shopilent.com",
-            Password = "Admin123!"
-        });
+        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login",
+            new { Email = "admin@shopilent.com", Password = "Admin123!" });
 
         AssertApiSuccess(loginResponse);
         var validRefreshToken = loginResponse!.Data.RefreshToken;
         var request = RefreshTokenTestDataV1.CreateValidRequest(validRefreshToken);
 
         // Act - Use the refresh token first time
-        var firstRefreshResponse = await PostApiResponseAsync<object, RefreshTokenResponseV1>("v1/auth/refresh-token", request);
+        var firstRefreshResponse =
+            await PostApiResponseAsync<object, RefreshTokenResponseV1>("v1/auth/refresh-token", request);
         AssertApiSuccess(firstRefreshResponse);
 
         // Act - Try to use the same refresh token again
@@ -161,11 +156,8 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First login to get a valid refresh token
         await EnsureAdminUserExistsAsync();
-        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login", new
-        {
-            Email = "admin@shopilent.com",
-            Password = "Admin123!"
-        });
+        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login",
+            new { Email = "admin@shopilent.com", Password = "Admin123!" });
 
         AssertApiSuccess(loginResponse);
         var validRefreshToken = loginResponse!.Data.RefreshToken;
@@ -195,11 +187,8 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - Login as customer to get a valid refresh token
         await EnsureCustomerUserExistsAsync();
-        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login", new
-        {
-            Email = "customer@shopilent.com",
-            Password = "Customer123!"
-        });
+        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login",
+            new { Email = "customer@shopilent.com", Password = "Customer123!" });
 
         AssertApiSuccess(loginResponse);
         var validRefreshToken = loginResponse!.Data.RefreshToken;
@@ -241,13 +230,13 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - First ensure we have a user in the database
         await EnsureAdminUserExistsAsync();
-        
+
         // Get initial user count to verify database integrity later
         var initialUserCount = await ExecuteDbContextAsync(async context =>
         {
             return await context.Users.CountAsync();
         });
-        
+
         var request = RefreshTokenTestDataV1.SecurityTests.CreateSqlInjectionAttempt();
 
         // Act
@@ -276,7 +265,7 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
 
         // Assert - Should reject with either BadRequest or Unauthorized
         response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.Unauthorized);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         content.Should().NotContain("<script>"); // Should not echo back the XSS payload
     }
@@ -384,11 +373,8 @@ public class RefreshTokenEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange - Login to get a valid refresh token
         await EnsureAdminUserExistsAsync();
-        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login", new
-        {
-            Email = "admin@shopilent.com",
-            Password = "Admin123!"
-        });
+        var loginResponse = await PostApiResponseAsync<object, LoginResponse>("v1/auth/login",
+            new { Email = "admin@shopilent.com", Password = "Admin123!" });
 
         AssertApiSuccess(loginResponse);
         var validRefreshToken = loginResponse!.Data.RefreshToken;

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/ChangePassword/V1/ChangePasswordEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/ChangePassword/V1/ChangePasswordEndpointV1Tests.cs
@@ -16,7 +16,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithValidData_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateValidChangePasswordRequest(
@@ -37,7 +37,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithValidCredentials_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateValidChangePasswordRequest(
@@ -57,7 +57,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithEmptyCurrentPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithEmptyCurrentPassword();
@@ -77,7 +77,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNullCurrentPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithNullCurrentPassword();
@@ -97,7 +97,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithEmptyNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithEmptyNewPassword();
@@ -117,7 +117,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNullNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithNullNewPassword();
@@ -137,7 +137,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithEmptyConfirmPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithEmptyConfirmPassword();
@@ -157,7 +157,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNullConfirmPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithNullConfirmPassword();
@@ -177,7 +177,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithMismatchedPasswords_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithMismatchedPasswords();
@@ -197,7 +197,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithSameCurrentAndNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithSameCurrentAndNewPassword();
@@ -217,7 +217,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithShortNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithShortNewPassword();
@@ -237,7 +237,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithWeakNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateRequestWithWeakNewPassword();
@@ -274,7 +274,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithWrongCurrentPassword_ShouldReturnUnauthorized()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateValidChangePasswordRequest(
@@ -298,7 +298,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNoUppercaseNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.PasswordStrengthTests.CreateRequestWithNoUppercaseNewPassword();
@@ -318,7 +318,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNoLowercaseNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.PasswordStrengthTests.CreateRequestWithNoLowercaseNewPassword();
@@ -338,7 +338,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNoNumberNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.PasswordStrengthTests.CreateRequestWithNoNumberNewPassword();
@@ -358,7 +358,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNoSpecialCharNewPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.PasswordStrengthTests.CreateRequestWithNoSpecialCharNewPassword();
@@ -379,7 +379,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithMinimumValidPassword_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.BoundaryTests.CreateRequestWithMinimumValidPassword();
@@ -396,7 +396,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithSevenCharacterPassword_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.BoundaryTests.CreateRequestWithSevenCharacterPassword();
@@ -416,7 +416,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithVeryLongPassword_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.BoundaryTests.CreateRequestWithVeryLongPassword();
@@ -433,7 +433,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithExtremelyLongPassword_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.BoundaryTests.CreateRequestWithExtremelyLongPassword();
@@ -450,7 +450,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithUnicodeCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.EdgeCases.CreateRequestWithUnicodeCharacters();
@@ -467,7 +467,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithWhitespaceInPasswords_ShouldPreserveExactValue()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.EdgeCases.CreateRequestWithWhitespaceInPasswords();
@@ -487,7 +487,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithOnlyWhitespace_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.EdgeCases.CreateRequestWithOnlyWhitespace();
@@ -507,7 +507,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithTabsAndNewlines_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.EdgeCases.CreateRequestWithTabsAndNewlines();
@@ -525,7 +525,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithSqlInjectionAttempt_ShouldReturnUnauthorizedSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.SecurityTests.CreateSqlInjectionAttempt();
@@ -547,7 +547,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithXssAttempt_ShouldReturnUnauthorizedSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.SecurityTests.CreateXssAttempt();
@@ -568,7 +568,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithCommandInjectionAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.SecurityTests.CreateCommandInjectionAttempt();
@@ -581,7 +581,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().NotBeNullOrEmpty();
-        
+
         // Ensure no system commands are executed
         content.Should().NotContain("rm");
         content.Should().NotContain("system");
@@ -592,7 +592,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithLongPasswordAttack_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.SecurityTests.CreateLongPasswordAttack();
@@ -611,7 +611,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_WithNullByteAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.SecurityTests.CreateNullByteAttempt();
@@ -640,7 +640,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
         string? currentPassword, string? newPassword, string? confirmPassword)
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = new
@@ -669,7 +669,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange - Test concurrent password change attempts (should be serialized)
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -696,7 +696,7 @@ public class ChangePasswordEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangePassword_ShouldNotExposePasswordsInResponse()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.PasswordScenarios.CreateValidChangePasswordRequest(

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/ChangeUserRole/V1/ChangeUserRoleEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/ChangeUserRole/V1/ChangeUserRoleEndpointV1Tests.cs
@@ -17,7 +17,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithValidAdminRequest_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -46,7 +45,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithValidCustomerRequest_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -75,7 +73,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithValidAdminRoleRequest_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -104,7 +101,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithNonExistentUser_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -126,7 +122,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithInvalidUserId_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -144,8 +139,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithInvalidRole_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -168,7 +162,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange
         ClearAuthenticationHeader();
-        await EnsureCustomerUserExistsAsync();
+
 
         var customerUserId = await GetUserIdByEmailAsync("customer@shopilent.com");
         var request = UserTestDataV1.RoleScenarios.CreateManagerRoleRequest();
@@ -184,7 +178,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithCustomerAuthentication_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var customerToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(customerToken);
 
@@ -202,7 +196,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_AdminChangingOwnRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -232,7 +225,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithAllValidRoles_ShouldReturnSuccess(UserRole targetRole)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -260,7 +252,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithEmptyGuid_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -279,8 +270,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithStringRole_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -298,8 +288,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithNegativeRole_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -321,8 +310,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithLargeRole_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -345,8 +333,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithSqlInjectionAttempt_ShouldReturnBadRequestSafely()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -370,8 +357,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithXssAttempt_ShouldReturnBadRequestSafely()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -394,8 +380,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_WithCommandInjectionAttempt_ShouldReturnBadRequestSafely()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -419,7 +404,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange - Test concurrent role changes (optimistic concurrency control)
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -466,7 +450,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange
         ClearAuthenticationHeader();
-        await EnsureCustomerUserExistsAsync();
+
 
         var customerUserId = await GetUserIdByEmailAsync("customer@shopilent.com");
         var request = UserTestDataV1.RoleScenarios.CreateManagerRoleRequest();
@@ -483,7 +467,7 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     {
         // Arrange
         SetAuthenticationHeader("malformed-token");
-        await EnsureCustomerUserExistsAsync();
+
 
         var customerUserId = await GetUserIdByEmailAsync("customer@shopilent.com");
         var request = UserTestDataV1.RoleScenarios.CreateManagerRoleRequest();
@@ -499,7 +483,6 @@ public class ChangeUserRoleEndpointV1Tests : ApiIntegrationTestBase
     public async Task ChangeUserRole_ShouldNotExposeUserDetailsInResponse()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/GetCurrentUserProfile/V1/GetCurrentUserProfileEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/GetCurrentUserProfile/V1/GetCurrentUserProfileEndpointV1Tests.cs
@@ -23,7 +23,6 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_WithAuthenticatedAdmin_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -44,7 +43,7 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_WithAuthenticatedCustomer_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -63,7 +62,7 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_WithManagerRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var managerUserId = await CreateTestUserWithRoleAsync("manager@example.com", "Manager", "Test", UserRole.Manager);
         var accessToken = await AuthenticateAsync("manager@example.com", "Password123!");
         SetAuthenticationHeader(accessToken);
@@ -115,7 +114,6 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_ShouldIncludeUserDetails()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -220,7 +218,7 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_MultipleConsecutiveRequests_ShouldReturnConsistentData()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -244,7 +242,6 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_ValidRequest_ShouldHaveReasonableResponseTime()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -297,7 +294,7 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_WithDifferentRoles_ShouldReturnCorrectRole(UserRole role)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var email = $"{role.ToString().ToLower()}role@example.com";
         var userId = await CreateTestUserWithRoleAsync(email, "Test", role.ToString(), role);
         var accessToken = await AuthenticateAsync(email, "Password123!");
@@ -317,7 +314,6 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetCurrentUserProfile_WithBearerTokenPrefix_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
 
         // The AuthenticateAsAdminAsync already returns token without Bearer prefix
@@ -326,13 +322,13 @@ public class GetCurrentUserProfileEndpointV1Tests : ApiIntegrationTestBase
 
         // Act
         var httpResponse = await Client.GetAsync("v1/users/me");
-        
+
         // Assert
         httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        
+
         var content = await httpResponse.Content.ReadAsStringAsync();
         content.Should().NotBeNullOrEmpty();
-        
+
         var response = JsonSerializer.Deserialize<ApiResponse<UserDetailDto>>(content, JsonOptions);
         AssertApiSuccess(response);
         response!.Data.Should().NotBeNull();

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/GetUser/V1/GetUserEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/GetUser/V1/GetUserEndpointV1Tests.cs
@@ -22,7 +22,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithValidIdAsAdmin_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -48,7 +47,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithValidIdAsAdmin_ShouldIncludeUserDetails()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -72,7 +70,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithNonExistentId_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var nonExistentId = UserTestDataV1.EdgeCases.CreateNonExistentUserId();
@@ -92,7 +89,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithInvalidGuid_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var invalidId = UserTestDataV1.EdgeCases.CreateMalformedUserId();
@@ -108,7 +104,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithEmptyGuid_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var emptyGuid = Guid.Empty;
@@ -138,7 +133,7 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var validUserId = UserTestDataV1.Creation.CreateValidUserId();
@@ -154,7 +149,7 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithManagerRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var managerId = await CreateTestUserWithRoleAsync("manager@example.com", "Manager", "User", UserRole.Manager);
         var accessToken = await AuthenticateAsync("manager@example.com", "Password123!");
         SetAuthenticationHeader(accessToken);
@@ -175,7 +170,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_RetrievingOwnProfileAsAdmin_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -201,7 +195,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithInactiveUser_ShouldReturnUserWithInactiveStatus()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -229,7 +222,8 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
             await CreateTestUserWithRoleAsync(adminEmail, "Manager", "Test", UserRole.Manager);
         }
 
-        var accessToken = await AuthenticateAsync(adminEmail, adminEmail == "admin@shopilent.com" ? "Admin123!" : "Password123!");
+        var accessToken = await AuthenticateAsync(adminEmail,
+            adminEmail == "admin@shopilent.com" ? "Admin123!" : "Password123!");
         SetAuthenticationHeader(accessToken);
 
         var testUserId = await CreateTestUserAsync("target@example.com", "Target", "User");
@@ -275,7 +269,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -302,7 +295,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithDatabaseConnectionFailure_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var validUserId = UserTestDataV1.Creation.CreateValidUserId();
@@ -319,7 +311,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithSqlInjectionAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var sqlInjectionId = UserTestDataV1.EdgeCases.CreateMalformedUserId();
@@ -340,7 +331,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithXssAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var xssId = UserTestDataV1.EdgeCases.CreateMalformedUserId();
@@ -361,7 +351,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_WithUnicodeInNames_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -384,7 +373,6 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUser_ValidRequest_ShouldHaveReasonableResponseTime()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -447,15 +435,10 @@ public class GetUserEndpointV1Tests : ApiIntegrationTestBase
         using var scope = Factory.Services.CreateScope();
         var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
-        var changeRoleCommand = new ChangeUserRoleCommandV1
-        {
-            UserId = userId,
-            NewRole = role
-        };
+        var changeRoleCommand = new ChangeUserRoleCommandV1 { UserId = userId, NewRole = role };
 
         await mediator.Send(changeRoleCommand);
 
         return userId;
     }
-
 }

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/GetUsersDatatable/V1/GetUsersDatatableEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/GetUsersDatatable/V1/GetUsersDatatableEndpointV1Tests.cs
@@ -19,7 +19,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithValidRequest_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest();
@@ -41,13 +40,13 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithTestUsers_ShouldReturnCorrectData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await EnsureCustomerUserExistsAsync();
-        
+
         // Create additional test users
         await CreateTestUserAsync("manager@test.com", "Test", "Manager", UserRole.Manager);
         await CreateTestUserAsync("customer2@test.com", "John", "Doe", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest(length: 10);
@@ -76,30 +75,32 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithPagination_ShouldReturnCorrectPage()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestUsersAsync(5);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
-        
+
         // First page
         var firstPageRequest = GetUsersDatatableTestDataV1.Pagination.CreateFirstPageRequest(pageSize: 3);
-        
+
         // Act
-        var firstPageResponse = await PostDataTableResponseAsync<UserDatatableDto>("v1/users/datatable", firstPageRequest);
+        var firstPageResponse =
+            await PostDataTableResponseAsync<UserDatatableDto>("v1/users/datatable", firstPageRequest);
 
         // Assert
         AssertApiSuccess(firstPageResponse);
         firstPageResponse!.Data.Data.Should().HaveCount(3);
         firstPageResponse.Data.RecordsTotal.Should().BeGreaterThanOrEqualTo(6); // Admin + 5 test users
-        
+
         // Second page
         var secondPageRequest = GetUsersDatatableTestDataV1.Pagination.CreateSecondPageRequest(pageSize: 3);
-        var secondPageResponse = await PostDataTableResponseAsync<UserDatatableDto>("v1/users/datatable", secondPageRequest);
-        
+        var secondPageResponse =
+            await PostDataTableResponseAsync<UserDatatableDto>("v1/users/datatable", secondPageRequest);
+
         AssertApiSuccess(secondPageResponse);
         secondPageResponse!.Data.Data.Should().HaveCount(3);
-        
+
         // Verify different users on different pages
         var firstPageIds = firstPageResponse.Data.Data.Select(u => u.Id).ToList();
         var secondPageIds = secondPageResponse.Data.Data.Select(u => u.Id).ToList();
@@ -110,10 +111,10 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithSearch_ShouldReturnFilteredResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("searchable@test.com", "Searchable", "User", UserRole.Customer);
         await CreateTestUserAsync("another@test.com", "Another", "Person", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SearchScenarios.CreateEmailSearchRequest("searchable");
@@ -133,11 +134,11 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithSorting_ShouldReturnSortedResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("alpha@test.com", "Alpha", "User", UserRole.Customer);
         await CreateTestUserAsync("beta@test.com", "Beta", "User", UserRole.Customer);
         await CreateTestUserAsync("gamma@test.com", "Gamma", "User", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SortingScenarios.CreateSortByEmailAscRequest();
@@ -149,7 +150,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
         AssertApiSuccess(response);
         response!.Data.Should().NotBeNull();
         response.Data.Data.Should().HaveCountGreaterThanOrEqualTo(4);
-        
+
         var sortedEmails = response.Data.Data.Select(u => u.Email).ToList();
         sortedEmails.Should().BeInAscendingOrder();
     }
@@ -158,11 +159,11 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithDescendingSortByCreatedAt_ShouldReturnNewestFirst()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var oldUserId = await CreateTestUserAsync("old@test.com", "Old", "User", UserRole.Customer);
         await Task.Delay(1000); // Ensure different timestamps
         var newUserId = await CreateTestUserAsync("new@test.com", "New", "User", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SortingScenarios.CreateSortByCreatedAtRequest();
@@ -173,7 +174,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
         // Assert
         AssertApiSuccess(response);
         response!.Data.Should().NotBeNull();
-        
+
         var sortedDates = response.Data.Data.Select(u => u.CreatedAt).ToList();
         sortedDates.Should().BeInDescendingOrder();
     }
@@ -196,7 +197,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest();
@@ -212,7 +213,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithManagerRole_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("manager@test.com", "Manager", "User", UserRole.Manager);
         var accessToken = await AuthenticateAsync("manager@test.com", "Password123!");
         SetAuthenticationHeader(accessToken);
@@ -230,7 +231,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithZeroLength_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.Pagination.CreateZeroLengthRequest();
@@ -240,7 +240,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         content.Should().NotBeNullOrEmpty();
     }
@@ -249,7 +249,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithNegativeValues_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.ValidationTests.CreateNegativeStartRequest();
@@ -265,7 +264,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithExcessiveLength_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.ValidationTests.CreateExcessiveLengthRequest();
@@ -281,7 +279,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithNoResultsSearch_ShouldReturnEmptyData()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SearchScenarios.CreateNoResultsSearchRequest();
@@ -301,9 +298,9 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithUnicodeSearch_ShouldReturnCorrectResults()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("unicode@test.com", "Müller", "Üser", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SearchScenarios.CreateUnicodeSearchRequest();
@@ -322,10 +319,10 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithComplexRequest_ShouldHandleAllParameters()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("complex1@test.com", "Test", "User", UserRole.Manager);
         await CreateTestUserAsync("complex2@test.com", "Another", "Manager", UserRole.Manager);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.EdgeCases.CreateComplexRequest();
@@ -344,7 +341,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithInvalidColumnSort_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SortingScenarios.CreateInvalidColumnSortRequest();
@@ -360,25 +356,24 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_ConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
-        
+
         var requests = Enumerable.Range(0, 5)
             .Select(i => GetUsersDatatableTestDataV1.CreateValidRequest(draw: i + 1))
             .ToList();
 
         // Act
-        var tasks = requests.Select(request => 
+        var tasks = requests.Select(request =>
             PostDataTableResponseAsync<UserDatatableDto>("v1/users/datatable", request)
         ).ToList();
-        
+
         var responses = await Task.WhenAll(tasks);
 
         // Assert
         responses.Should().AllSatisfy(response => AssertApiSuccess(response));
         responses.Should().HaveCount(5);
-        
+
         // Verify each response has correct draw number
         for (int i = 0; i < responses.Length; i++)
         {
@@ -390,9 +385,9 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithEmptySearch_ShouldReturnAllUsers()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateTestUserAsync("empty@test.com", "Empty", "Search", UserRole.Customer);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.SearchScenarios.CreateEmptySearchRequest();
@@ -411,7 +406,6 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithHighPageNumber_ShouldReturnEmptyOrLastPage()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.Pagination.CreateHighStartRequest();
@@ -431,10 +425,10 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_DatabaseConsistency_ShouldMatchDatabaseCounts()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         var testUser1Id = await CreateTestUserAsync("db1@test.com", "Database", "User1", UserRole.Customer);
         var testUser2Id = await CreateTestUserAsync("db2@test.com", "Database", "User2", UserRole.Manager);
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest(length: 100); // Get all users
@@ -444,14 +438,14 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
 
         // Assert
         AssertApiSuccess(response);
-        
+
         // Verify against database
         await ExecuteDbContextAsync(async context =>
         {
             var totalUsersInDb = await context.Users.CountAsync();
             response!.Data.RecordsTotal.Should().Be(totalUsersInDb);
             response.Data.RecordsFiltered.Should().Be(totalUsersInDb);
-            
+
             // Verify specific test users are included
             var testUserIds = new[] { testUser1Id, testUser2Id };
             var responseIds = response.Data.Data.Select(u => u.Id).ToList();
@@ -467,9 +461,9 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_WithDifferentPageSizes_ShouldReturnCorrectCount(int pageSize)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestUsersAsync(15); // Create enough users to test pagination
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest(length: pageSize);
@@ -480,7 +474,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
         // Assert
         AssertApiSuccess(response);
         response!.Data.Should().NotBeNull();
-        
+
         // Should return at most pageSize items, but could be less if not enough data
         response.Data.Data.Should().HaveCountLessOrEqualTo(pageSize);
         response.Data.RecordsTotal.Should().BeGreaterThanOrEqualTo(response.Data.Data.Count);
@@ -490,9 +484,9 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     public async Task GetUsersDatatable_ResponseTime_ShouldBeReasonable()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await CreateMultipleTestUsersAsync(50); // Create a decent amount of data
-        
+
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = GetUsersDatatableTestDataV1.CreateValidRequest();
@@ -508,7 +502,8 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
     }
 
     // Helper methods
-    private async Task<Guid> CreateTestUserAsync(string email, string firstName, string lastName, UserRole role = UserRole.Customer)
+    private async Task<Guid> CreateTestUserAsync(string email, string firstName, string lastName,
+        UserRole role = UserRole.Customer)
     {
         using var scope = Factory.Services.CreateScope();
         var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
@@ -533,11 +528,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
             // Change role if not customer
             if (role != UserRole.Customer)
             {
-                var changeRoleCommand = new ChangeUserRoleCommandV1
-                {
-                    UserId = userId,
-                    NewRole = role
-                };
+                var changeRoleCommand = new ChangeUserRoleCommandV1 { UserId = userId, NewRole = role };
                 await mediator.Send(changeRoleCommand);
             }
 
@@ -558,7 +549,7 @@ public class GetUsersDatatableEndpointV1Tests : ApiIntegrationTestBase
             var firstName = $"Test{i}";
             var lastName = $"User{i}";
             var role = roles[i % roles.Length];
-            
+
             tasks.Add(CreateTestUserAsync(email, firstName, lastName, role));
         }
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateProfile/V1/UpdateProfileEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateProfile/V1/UpdateProfileEndpointV1Tests.cs
@@ -17,7 +17,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidData_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Creation.CreateValidProfileUpdateRequest(
@@ -44,7 +44,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidData_ShouldUpdateUserInDatabase()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Creation.CreateValidProfileUpdateRequest(
@@ -78,7 +78,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithEmptyFirstName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithEmptyFirstName();
@@ -98,7 +98,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNullFirstName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithNullFirstName();
@@ -118,7 +118,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithEmptyLastName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithEmptyLastName();
@@ -138,7 +138,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNullLastName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithNullLastName();
@@ -158,7 +158,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNullMiddleName_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithNullMiddleName();
@@ -175,7 +175,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithEmptyMiddleName_ShouldTreatAsNull()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithEmptyMiddleName();
@@ -193,7 +193,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNullPhone_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithNullPhone();
@@ -220,7 +220,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithEmptyPhone_ShouldTreatAsNull()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithEmptyPhone();
@@ -249,7 +249,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithInvalidPhone_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithInvalidPhone();
@@ -269,7 +269,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidInternationalPhone_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithValidInternationalPhone();
@@ -286,7 +286,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithInvalidCharactersInName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Validation.CreateRequestWithInvalidCharactersInName();
@@ -320,7 +320,6 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithAdminUser_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Creation.CreateValidProfileUpdateRequest(
@@ -347,16 +346,10 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
         string? firstName, string? lastName, string? middleName, string? phone)
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
-        var request = new
-        {
-            FirstName = firstName,
-            LastName = lastName,
-            MiddleName = middleName,
-            Phone = phone
-        };
+        var request = new { FirstName = firstName, LastName = lastName, MiddleName = middleName, Phone = phone };
 
         // Act
         var response = await PutAsync("v1/users/me", request);
@@ -376,7 +369,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithSingleCharacterName_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.BoundaryTests.CreateRequestWithSingleCharacterName();
@@ -395,7 +388,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithMaximumLengthNames_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.BoundaryTests.CreateRequestWithMaximumLengthNames();
@@ -414,7 +407,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithLongNames_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.BoundaryTests.CreateRequestWithLongNames();
@@ -435,7 +428,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithUnicodeCharacters_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithUnicodeCharacters();
@@ -455,7 +448,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithSpecialCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithSpecialCharacters();
@@ -474,7 +467,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithWhitespaceInNames_ShouldPreserveWhitespace()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithWhitespaceInNames();
@@ -494,7 +487,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithOnlyWhitespace_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithOnlyWhitespace();
@@ -516,7 +509,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithTabsAndNewlines_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithTabsAndNewlines();
@@ -534,7 +527,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNumericNames_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithNumericNames();
@@ -554,7 +547,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithEmojis_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithEmojis();
@@ -574,7 +567,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidSpecialCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithValidSpecialCharacters();
@@ -593,7 +586,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidDotsAndSpaces_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.EdgeCases.CreateRequestWithValidDotsAndSpaces();
@@ -613,7 +606,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithSqlInjectionAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.SecurityTests.CreateSqlInjectionAttempt();
@@ -641,7 +634,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithXssAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.SecurityTests.CreateXssAttempt();
@@ -667,7 +660,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithCommandInjectionAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.SecurityTests.CreateCommandInjectionAttempt();
@@ -695,7 +688,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithLongStringAttack_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.SecurityTests.CreateLongStringAttack();
@@ -715,7 +708,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithNullByteAttempt_ShouldHandleSafely()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.SecurityTests.CreateNullByteAttempt();
@@ -736,15 +729,13 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange - Test concurrent profile updates (optimistic concurrency control)
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
         var validNameVariations = new[]
         {
-            ("John", "Smith", "James"),
-            ("Jane", "Johnson", "Marie"),
-            ("Michael", "Brown", "Robert")
+            ("John", "Smith", "James"), ("Jane", "Johnson", "Marie"), ("Michael", "Brown", "Robert")
         };
 
         var requests = Enumerable.Range(0, 3)
@@ -774,7 +765,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
         if (failedResponses.Any())
         {
             failedResponses.Should().AllSatisfy(response =>
-                response.StatusCode.Should().Be(HttpStatusCode.Conflict),
+                    response.StatusCode.Should().Be(HttpStatusCode.Conflict),
                 "Failed responses should be 409 Conflict due to concurrency violations");
         }
 
@@ -795,7 +786,7 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_ShouldNotExposeUserDetailsInResponse()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
         var request = UserTestDataV1.Creation.CreateValidProfileUpdateRequest(
@@ -848,7 +839,6 @@ public class UpdateProfileEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateProfile_WithValidToken_ShouldUpdateCorrectUser()
     {
         // Arrange - Test that the update affects only the authenticated user
-        await EnsureCustomerUserExistsAsync();
         await EnsureAdminUserExistsAsync();
         var customerToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(customerToken);

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateUser/V1/UpdateUserEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateUser/V1/UpdateUserEndpointV1Tests.cs
@@ -24,7 +24,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithValidDataAsAdmin_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -49,7 +48,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithValidDataAsAdmin_ShouldUpdateUserInDatabase()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -79,7 +77,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithValidDataAsManager_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureManagerUserExistsAsync();
         var accessToken = await AuthenticateAsManagerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -100,7 +97,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithOnlyRequiredFields_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -123,7 +119,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithAllFields_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -152,7 +147,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithInvalidFirstName_ShouldReturnValidationError(string? invalidFirstName)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -174,7 +168,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithInvalidLastName_ShouldReturnValidationError(string? invalidLastName)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -194,7 +187,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithTooLongFirstName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -214,7 +206,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithTooLongLastName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -234,7 +225,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithTooLongMiddleName_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -259,7 +249,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithInvalidPhoneFormat_ShouldReturnValidationError(string invalidPhone)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -284,7 +273,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithMaximumLengthNames_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -303,7 +291,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithMinimumValidPhone_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -322,7 +309,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithMaximumValidPhone_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -360,7 +346,7 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var accessToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -382,7 +368,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithNonExistentUserId_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -402,7 +387,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithInvalidGuidFormat_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -424,7 +408,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithUnicodeCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -446,7 +429,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithSpecialCharacters_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -467,7 +449,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithInternationalPhoneNumber_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -487,7 +468,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_WithPhoneNumberWithoutPlus_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 
@@ -507,7 +487,6 @@ public class UpdateUserEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUser_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var accessToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(accessToken);
 

--- a/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateUserStatus/V1/UpdateUserStatusEndpointV1Tests.cs
+++ b/Shopilent.API.IntegrationTests/Endpoints/Users/UpdateUserStatus/V1/UpdateUserStatusEndpointV1Tests.cs
@@ -23,7 +23,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_AdminActivatingInactiveUser_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -57,7 +56,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_AdminDeactivatingActiveUser_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -87,9 +85,7 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_ManagerUpdatingUserStatus_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
-        await EnsureManagerUserExistsAsync();
+        await EnsureTestUsersExistAsync();
         var managerToken = await AuthenticateAsManagerAsync();
         SetAuthenticationHeader(managerToken);
 
@@ -121,7 +117,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_AdminTryingToDeactivateSelf_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -144,7 +139,7 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_ManagerTryingToDeactivateSelf_ShouldReturnValidationError()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
+
         await EnsureManagerUserExistsAsync();
         var managerToken = await AuthenticateAsManagerAsync();
         SetAuthenticationHeader(managerToken);
@@ -167,7 +162,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_AdminActivatingSelf_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -206,7 +200,7 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithCustomerRole_ShouldReturnForbidden()
     {
         // Arrange
-        await EnsureCustomerUserExistsAsync();
+
         var customerToken = await AuthenticateAsCustomerAsync();
         SetAuthenticationHeader(customerToken);
 
@@ -239,7 +233,8 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithExpiredToken_ShouldReturnUnauthorized()
     {
         // Arrange
-        var expiredToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        var expiredToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         SetAuthenticationHeader(expiredToken);
         var userId = Guid.NewGuid();
         var request = UserTestDataV1.StatusScenarios.CreateValidRequest();
@@ -259,7 +254,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithNonExistentUserId_ShouldReturnNotFound()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -286,7 +280,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithInvalidGuidFormats_ShouldReturnBadRequest(string invalidGuid)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -307,7 +300,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_ActivatingAlreadyActiveUser_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -339,7 +331,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_DeactivatingAlreadyInactiveUser_ShouldReturnSuccess()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -376,7 +367,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithValidBooleanValues_ShouldReturnSuccess(object request)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -397,8 +387,7 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithInvalidBooleanValues_ShouldReturnBadRequest(object request)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -419,8 +408,8 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithMalformedJson_ShouldReturnBadRequest()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
-        await EnsureCustomerUserExistsAsync();
+
+
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
 
@@ -438,7 +427,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithEmptyJson_ShouldDeactivateUser()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -472,7 +460,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_WithSecurityPayloads_ShouldHandleSafely(object maliciousPayload)
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -503,7 +490,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_MultipleConcurrentRequests_ShouldHandleGracefully()
     {
         // Arrange - Test concurrent status changes (should be serialized due to database contention)
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -532,7 +518,7 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
         if (failedResponses.Any())
         {
             failedResponses.Should().AllSatisfy(response =>
-                response.StatusCode.Should().Be(HttpStatusCode.Conflict),
+                    response.StatusCode.Should().Be(HttpStatusCode.Conflict),
                 "Failed responses should be 409 Conflict due to concurrency violations");
         }
 
@@ -554,7 +540,6 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
     public async Task UpdateUserStatus_MultipleSequentialRequests_ShouldCompleteWithinReasonableTime()
     {
         // Arrange
-        await EnsureAdminUserExistsAsync();
         await EnsureCustomerUserExistsAsync();
         var adminToken = await AuthenticateAsAdminAsync();
         SetAuthenticationHeader(adminToken);
@@ -672,14 +657,14 @@ public class UpdateUserStatusEndpointV1Tests : ApiIntegrationTestBase
                 // Change role to Manager using the ChangeUserRoleCommand
                 var changeRoleCommand = new ChangeUserRoleCommandV1
                 {
-                    UserId = registerResult.Value.User.Id,
-                    NewRole = UserRole.Manager
+                    UserId = registerResult.Value.User.Id, NewRole = UserRole.Manager
                 };
 
                 var changeRoleResult = await sender.Send(changeRoleCommand);
                 if (changeRoleResult.IsFailure)
                 {
-                    throw new InvalidOperationException($"Failed to change user role to Manager: {changeRoleResult.Error}");
+                    throw new InvalidOperationException(
+                        $"Failed to change user role to Manager: {changeRoleResult.Error}");
                 }
             }
         });


### PR DESCRIPTION
- Cleaned up `EnsureAdminUserExistsAsync` and `EnsureCustomerUserExistsAsync` calls across test files.
- Simplified test setup for catalog attributes, user management, and cache-clearing endpoints.
- Improved test maintainability while aligning with streamlined setup strategies.