### PR TITLE
feat(rate-limiting): add trusted network bypass for IP rate limiting

### DIFF
--- a/src/API/Shopilent.API/Common/Configuration/RateLimitingOptions.cs
+++ b/src/API/Shopilent.API/Common/Configuration/RateLimitingOptions.cs
@@ -8,6 +8,7 @@ public sealed class RateLimitingOptions
     public string ApiPrefix { get; set; } = "/api";
     public PolicyOptions Normal { get; set; } = new();
     public PolicyOptions Auth { get; set; } = new();
+    public List<string> TrustedNetworks { get; set; } = ["172.16.0.0/12", "10.0.0.0/8", "192.168.0.0/16"];
 }
 
 public sealed class PolicyOptions

--- a/src/API/Shopilent.API/Common/Extensions/RateLimitingExtensions.cs
+++ b/src/API/Shopilent.API/Common/Extensions/RateLimitingExtensions.cs
@@ -13,6 +13,6 @@ public static class RateLimitingExtensions
 
     public static IApplicationBuilder UseApiRateLimiting(this IApplicationBuilder app)
     {
-        return app.UseMiddleware<IpRateLimitingMiddleware>();
+        return app.UseMiddleware<RateLimitingMiddleware>();
     }
 }

--- a/src/API/Shopilent.API/Program.cs
+++ b/src/API/Shopilent.API/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FastEndpoints;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Scalar.AspNetCore;
 using Shopilent.API.Common.Extensions;
 using Shopilent.API.Common.Services;
@@ -53,6 +54,20 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+// Configure forwarded headers for reverse proxy (Traefik, nginx, etc.)
+// This is essential for cookies, HTTPS detection, and client IP when behind a proxy
+var forwardedHeadersOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+};
+
+// In production behind Docker network, trust the proxy network
+// In development without proxy, this has no effect
+forwardedHeadersOptions.KnownNetworks.Clear();
+forwardedHeadersOptions.KnownProxies.Clear();
+
+app.UseForwardedHeaders(forwardedHeadersOptions);
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
- Introduce `TrustedNetworks` configuration in `RateLimitingOptions`.
- Allow requests from trusted networks to bypass rate limiting.
- Extend IP rate-limiting middleware with CIDR-based trusted network checks.